### PR TITLE
Filter satellites with id's > 32

### DIFF
--- a/haskell/src/Data/RTCM3/SBP.hs
+++ b/haskell/src/Data/RTCM3/SBP.hs
@@ -76,6 +76,7 @@ toSid sat = GnssSignal
 
 fromObservation1002 :: Observation1002 -> Maybe PackedObsContent
 fromObservation1002 obs =
+  -- Only lower set of PRN numbers (1-32) are supported
   if sat > 32 then Nothing else
     if obs ^. observation1002_l1 ^. gpsL1Observation_code then Nothing else Just PackedObsContent
       { _packedObsContent_P    = toP l1 l1e
@@ -90,6 +91,7 @@ fromObservation1002 obs =
 
 fromObservation1004 :: Observation1004 -> Maybe PackedObsContent
 fromObservation1004 obs =
+  -- Only lower set of PRN numbers (1-32) are supported
   if sat > 32 then Nothing else
     if obs ^. observation1004_l1 ^. gpsL1Observation_code then Nothing else Just PackedObsContent
       { _packedObsContent_P    = toP l1 l1e

--- a/haskell/src/Data/RTCM3/SBP.hs
+++ b/haskell/src/Data/RTCM3/SBP.hs
@@ -76,29 +76,31 @@ toSid sat = GnssSignal
 
 fromObservation1002 :: Observation1002 -> Maybe PackedObsContent
 fromObservation1002 obs =
-  if obs ^. observation1002_l1 ^. gpsL1Observation_code then Nothing else Just PackedObsContent
-    { _packedObsContent_P    = toP l1 l1e
-    , _packedObsContent_L    = toL l1 l1e
-    , _packedObsContent_cn0  = toCn0 l1e
-    , _packedObsContent_lock = toLock l1
-    , _packedObsContent_sid  = toSid sat
-    } where
-      sat = obs ^. observation1002_sat
-      l1  = obs ^. observation1002_l1
-      l1e = obs ^. observation1002_l1e
+  if sat > 32 then Nothing else
+    if obs ^. observation1002_l1 ^. gpsL1Observation_code then Nothing else Just PackedObsContent
+      { _packedObsContent_P    = toP l1 l1e
+      , _packedObsContent_L    = toL l1 l1e
+      , _packedObsContent_cn0  = toCn0 l1e
+      , _packedObsContent_lock = toLock l1
+      , _packedObsContent_sid  = toSid sat
+      } where
+        sat = obs ^. observation1002_sat
+        l1  = obs ^. observation1002_l1
+        l1e = obs ^. observation1002_l1e
 
 fromObservation1004 :: Observation1004 -> Maybe PackedObsContent
 fromObservation1004 obs =
-  if obs ^. observation1004_l1 ^. gpsL1Observation_code then Nothing else Just PackedObsContent
-    { _packedObsContent_P    = toP l1 l1e
-    , _packedObsContent_L    = toL l1 l1e
-    , _packedObsContent_cn0  = toCn0 l1e
-    , _packedObsContent_lock = toLock l1
-    , _packedObsContent_sid  = toSid sat
-    }  where
-      sat = obs ^. observation1004_sat
-      l1  = obs ^. observation1004_l1
-      l1e = obs ^. observation1004_l1e
+  if sat > 32 then Nothing else
+    if obs ^. observation1004_l1 ^. gpsL1Observation_code then Nothing else Just PackedObsContent
+      { _packedObsContent_P    = toP l1 l1e
+      , _packedObsContent_L    = toL l1 l1e
+      , _packedObsContent_cn0  = toCn0 l1e
+      , _packedObsContent_lock = toLock l1
+      , _packedObsContent_sid  = toSid sat
+      }  where
+        sat = obs ^. observation1004_sat
+        l1  = obs ^. observation1004_l1
+        l1e = obs ^. observation1004_l1e
 
 fromMsg1002 :: MonadIO m => Msg1002 -> m MsgObs
 fromMsg1002 m = do


### PR DESCRIPTION
Fixes #9.

Don't convert satellite id's > 32.

/cc @ljbade 