### PR TITLE
Week Number rollover

### DIFF
--- a/haskell/gnss-converters.cabal
+++ b/haskell/gnss-converters.cabal
@@ -80,6 +80,7 @@ test-suite test
                      , gnss-converters
                      , lens
                      , resourcet
+                     , rtcm
                      , sbp
                      , tasty
                      , tasty-hunit

--- a/haskell/src/Data/RTCM3/SBP/Types.hs
+++ b/haskell/src/Data/RTCM3/SBP/Types.hs
@@ -27,6 +27,9 @@ import Control.Monad.Trans.Control
 import Control.Monad.Trans.Resource
 import Data.IORef
 import Data.Word
+import SwiftNav.SBP
+
+type GPSTimeMap = HashMap Word16 ObsGPSTime
 
 newtype ConvertT e m a = ConvertT { unConvertT :: ReaderT e m a }
   deriving
@@ -58,7 +61,8 @@ instance MonadBase b m => MonadBase b (ConvertT r m) where
     liftBase = liftBaseDefault
 
 data Store = Store
-  { _storeWn :: IORef Word16
+  { _storeWn         :: IORef Word16
+  , _storeGPSTimeMap :: IORef GPSTimeMap
   } deriving ( Eq )
 
 $(makeClassy ''Store)


### PR DESCRIPTION
Handle week number rolling over by keeping track of wn and tow per station:

1. On first observation, pick up the global week number and save it with the tow for the station.
2. On subsequent observations, pick up the saved `(tow, wn)` for the station.
3. If old tow > new tow, increment wn.

/cc @mookerji @ljbade 