### PR TITLE
Lock timer conversion

### DIFF
--- a/haskell/gnss-converters.cabal
+++ b/haskell/gnss-converters.cabal
@@ -29,6 +29,7 @@ library
                      , lens
                      , monad-control
                      , mtl
+                     , random
                      , resourcet
                      , rtcm
                      , sbp


### PR DESCRIPTION
Convert RTCM3 lock timer to  SBP lock counter. General strategy:

### Convert RTCM3 Lock Time Indicator to SBP Lock Indicator

RTCM3 and SBP represent satellite signal lock differently. RTCM3 uses
a scaled value initialized to 0 to capture the amount of time that a
receiver has maintained a continuous lock of a satellite signal. SBP
uses a counter initialized to a random value that increments on the
loss of continuous lock of a satellite signal. This note concerns only
converting from RTCM3 to SBP.

In RTCM3, lock time is captured by a Minimum Lock Time (MLT), and
cycle slip is reflected by a decrease in MLT. To convert between RTCM3
and SBP, the following approach will be taken:

1. Initialize an initial lock counter for a station with a random
value - this will be the initial SBP lock counter value.

2. Store the incoming RTCM3 MLT values.

3. If the incoming MLT value is less than the stored MLT value,
increment the stored lock counter value.

4. Send out the stored lock counter value.

/cc @ljbade @mookerji 

