### PR TITLE
Invalid measurements

### DIFF
--- a/haskell/src/Data/RTCM3/SBP.hs
+++ b/haskell/src/Data/RTCM3/SBP.hs
@@ -434,11 +434,11 @@ fromMsg1002 m = do
 fromObservation1004 :: MonadStore e m => Word16 -> Observation1004 -> m [PackedObsContent]
 fromObservation1004 station obs =
   -- Only lower set of PRN numbers (1-32) are supported
-  if sat > maxSats || invalid_L1 l1 then return mempty else do
-    obs1 <- fromL1SatelliteObservation station sat l1 l1e
-    if invalid_L2 l2 then return [obs1] else do
-      obs2 <- fromL2SatelliteObservation station sat l1 l1e l2 l2e
-      return $ maybe [obs1] (: [obs1]) obs2
+  if sat > maxSats || invalid_L2 l2 then return mempty else do
+    obs2 <- fromL2SatelliteObservation station sat l1 l1e l2 l2e
+    if invalid_L1 l1 then return $ maybeToList obs2 else do
+      obs1 <- fromL1SatelliteObservation station sat l1 l1e
+      return $ obs1 : maybeToList obs2
       where
         sat = obs ^. observation1004_sat
         l1  = obs ^. observation1004_l1

--- a/haskell/src/Data/RTCM3/SBP.hs
+++ b/haskell/src/Data/RTCM3/SBP.hs
@@ -197,6 +197,7 @@ invalid_L1 l1 =
 -- See DF011, DF012, and DF018 of the RTCM3 spec
 invalid_L2 :: GpsL2Observation -> Bool
 invalid_L2 l2 =
+  l2 ^. gpsL2Observation_pseudorangeDifference == 0x2000 ||
   l2 ^. gpsL2Observation_carrierMinusCode == 0x80000
 
 -- | Construct metric pseudorange (meters!) from L1 RTCM observation.


### PR DESCRIPTION
Filter out invalid measurements. DF011, DF012, and DF018 measurements with a value of `80000h` are invalid. Throw away observations if these values are set, along the following lines:

+ 1002: if DF011 or DF012 are invalid, throw away L1 obs
+ 1004: if DF011 or DF012 are invalid, throw away L1 and L2 obs; if DF018 is invalid, throw away L2 obs

The documentation indicates that the L2 obs can be processed while DF011 or DF012 are invalid; but we actively use those fields to produce a L2 obs.

/cc @mookerji @ljbade 