### PR TITLE
Enable Hackage-friendly stack.yaml settings

### DIFF
--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -8,3 +8,4 @@ extra-deps:
 - word24-2.0.1
 - binary-bits-0.5
 - HUnit-approx-1.1
+pvp-bounds: both


### PR DESCRIPTION
This will transparently add upper and lower bounds to all package dependencies not currently having them, based on the snapshot in use, when the package is uploaded via either stack upload or stack sdist.