### PR TITLE
Support sender id from RTCM message station ID

### DIFF
--- a/c/include/rtcm3_sbp.h
+++ b/c/include/rtcm3_sbp.h
@@ -25,7 +25,8 @@ struct rtcm3_sbp_state {
   bool leap_second_known;
   msg_obs_t *sbp_obs_buffer;
   u8 obs_buffer[sizeof(observation_header_t) + MAX_OBS_PER_EPOCH * sizeof(packed_obs_content_t)];
-  void (*cb)(u8 msg_id, u8 buff, u8 *len);
+  u16 sender_id;
+  void (*cb)(u8 msg_id, u8 buff, u8 *len, u16 sender_id);
 };
 
 void rtcm2sbp_decode_frame(const uint8_t *frame, uint32_t frame_length, struct rtcm3_sbp_state *state);
@@ -34,6 +35,7 @@ void rtcm2sbp_set_gps_time(gps_time_sec_t *current_time, struct rtcm3_sbp_state*
 
 void rtcm2sbp_set_leap_second(s8 leap_seconds, struct rtcm3_sbp_state *state);
 
-void rtcm2sbp_init(struct rtcm3_sbp_state *state, void (*cb)(u8 msg_id, u8 length, u8 *buffer));
+void rtcm2sbp_init(struct rtcm3_sbp_state *state,
+                   void (*cb)(u8 msg_id, u8 length, u8 *buffer, u16 sender_id));
 
 #endif //GNSS_CONVERTERS_RTCM3_SBP_INTERFACE_H

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -16,7 +16,8 @@
 #include <string.h>
 #include <assert.h>
 
-void rtcm2sbp_init(struct rtcm3_sbp_state *state, void (*cb)(u8 msg_id, u8 length, u8 *buffer))
+void rtcm2sbp_init(struct rtcm3_sbp_state *state,
+                   void (*cb)(u8 msg_id, u8 length, u8 *buffer, u16 sender_id))
 {
   state->time_from_rover_obs.wn = 0;
   state->time_from_rover_obs.tow = 0;
@@ -78,7 +79,8 @@ void rtcm2sbp_decode_frame(const uint8_t *frame, uint32_t frame_length, struct r
     if (0 == rtcm3_decode_1005(&frame[byte], &msg_1005)) {
       msg_base_pos_ecef_t sbp_base_pos;
       rtcm3_1005_to_sbp(&msg_1005, &sbp_base_pos);
-      state->cb(SBP_MSG_BASE_POS_ECEF, (u8)sizeof(sbp_base_pos), (u8 *)&sbp_base_pos);
+      state->cb(SBP_MSG_BASE_POS_ECEF, (u8)sizeof(sbp_base_pos),
+                (u8 *)&sbp_base_pos, msg_1005.stn_id);
     }
     break;
   }
@@ -87,7 +89,8 @@ void rtcm2sbp_decode_frame(const uint8_t *frame, uint32_t frame_length, struct r
     if (0 == rtcm3_decode_1006(&frame[byte], &msg_1006)) {
       msg_base_pos_ecef_t sbp_base_pos;
       rtcm3_1006_to_sbp(&msg_1006, &sbp_base_pos);
-      state->cb(SBP_MSG_BASE_POS_ECEF, (u8)sizeof(sbp_base_pos), (u8 *)&sbp_base_pos);
+      state->cb(SBP_MSG_BASE_POS_ECEF, (u8)sizeof(sbp_base_pos),
+                (u8 *)&sbp_base_pos, msg_1006.msg_1005.stn_id);
     }
     break;
   }
@@ -114,7 +117,8 @@ void rtcm2sbp_decode_frame(const uint8_t *frame, uint32_t frame_length, struct r
       /* 1230 Message needs SBP message support to send
       msg_glo_code_phase_bias_t sbp_glo_cpb;
       rtcm3_1230_to_sbp(&msg_1230, &sbp_glo_cpb);
-      state->cb(SBP_MSG_GLO_CODE_PHASE_BIAS, (u8)sizeof(sbp_glo_cpb), (u8 *)&sbp_glo_cpb); */
+      state->cb(SBP_MSG_GLO_CODE_PHASE_BIAS, (u8)sizeof(sbp_glo_cpb),
+       (u8 *)&sbp_glo_cpb, msg1230.stn_id); */
     }
   }
   default:
@@ -156,7 +160,8 @@ void add_obs_to_buffer(const rtcm_obs_message *new_rtcm_obs, gps_time_sec_t *obs
 
   // Check if the buffer already has obs of the same time
   if(sbp_obs_buffer->header.n_obs != 0 &&
-     (sbp_obs_buffer->header.t.tow != new_sbp_obs->header.t.tow)) {
+     (sbp_obs_buffer->header.t.tow != new_sbp_obs->header.t.tow
+      || state->sender_id != new_rtcm_obs->header.stn_id)) {
     // We either have missed a message, or we have a new station. Either way,
     // send through the current buffer and clear before adding new obs
     send_observations(state);
@@ -164,6 +169,7 @@ void add_obs_to_buffer(const rtcm_obs_message *new_rtcm_obs, gps_time_sec_t *obs
 
   // Copy new obs into buffer
   u8 obs_index_buffer = sbp_obs_buffer->header.n_obs;
+  state->sender_id = new_rtcm_obs->header.stn_id;
   for(u8 obs_count = 0; obs_count < new_sbp_obs->header.n_obs; obs_count++) {
     sbp_obs_buffer->obs[obs_index_buffer] = new_sbp_obs->obs[obs_count];
     obs_index_buffer++;
@@ -215,7 +221,7 @@ void send_observations(struct rtcm3_sbp_state *state)
 
   for (u8 msg = 0; msg < total_messages; ++msg) {
     sbp_obs[msg]->header.n_obs = (total_messages << 4) + msg;
-    state->cb(SBP_MSG_OBS, sizes[msg], (u8 *) sbp_obs[msg]);
+    state->cb(SBP_MSG_OBS, sizes[msg], (u8 *) sbp_obs[msg], state->sender_id);
   }
 
   memset((void*)sbp_obs_buffer,0, sizeof(*sbp_obs_buffer));

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -38,6 +38,12 @@ static double gps_diff_time(const gps_time_sec_t *end, const gps_time_sec_t *beg
   return dt;
 }
 
+static u16 rtcm_2_sbp_sender_id(u16 rtcm_id){
+  /* To avoid conflicts with reserved low number sender ID's we or
+   * on the highest nibble as RTCM sender ID's are 12 bit */
+  return rtcm_id | 0xF000;
+}
+
 void rtcm2sbp_decode_frame(const uint8_t *frame, uint32_t frame_length, struct rtcm3_sbp_state *state)
 {
   if (state->gps_time_updated == false || frame_length < 1) {
@@ -80,7 +86,7 @@ void rtcm2sbp_decode_frame(const uint8_t *frame, uint32_t frame_length, struct r
       msg_base_pos_ecef_t sbp_base_pos;
       rtcm3_1005_to_sbp(&msg_1005, &sbp_base_pos);
       state->cb(SBP_MSG_BASE_POS_ECEF, (u8)sizeof(sbp_base_pos),
-                (u8 *)&sbp_base_pos, msg_1005.stn_id);
+                (u8 *)&sbp_base_pos, rtcm_2_sbp_sender_id(msg_1005.stn_id));
     }
     break;
   }
@@ -90,7 +96,7 @@ void rtcm2sbp_decode_frame(const uint8_t *frame, uint32_t frame_length, struct r
       msg_base_pos_ecef_t sbp_base_pos;
       rtcm3_1006_to_sbp(&msg_1006, &sbp_base_pos);
       state->cb(SBP_MSG_BASE_POS_ECEF, (u8)sizeof(sbp_base_pos),
-                (u8 *)&sbp_base_pos, msg_1006.msg_1005.stn_id);
+                (u8 *)&sbp_base_pos, rtcm_2_sbp_sender_id(msg_1006.msg_1005.stn_id));
     }
     break;
   }
@@ -118,7 +124,7 @@ void rtcm2sbp_decode_frame(const uint8_t *frame, uint32_t frame_length, struct r
       msg_glo_code_phase_bias_t sbp_glo_cpb;
       rtcm3_1230_to_sbp(&msg_1230, &sbp_glo_cpb);
       state->cb(SBP_MSG_GLO_CODE_PHASE_BIAS, (u8)sizeof(sbp_glo_cpb),
-       (u8 *)&sbp_glo_cpb, msg1230.stn_id); */
+       (u8 *)&sbp_glo_cpb, rtcm_2_sbp_sender_id(msg1230.stn_id)); */
     }
   }
   default:
@@ -161,7 +167,7 @@ void add_obs_to_buffer(const rtcm_obs_message *new_rtcm_obs, gps_time_sec_t *obs
   // Check if the buffer already has obs of the same time
   if(sbp_obs_buffer->header.n_obs != 0 &&
      (sbp_obs_buffer->header.t.tow != new_sbp_obs->header.t.tow
-      || state->sender_id != new_rtcm_obs->header.stn_id)) {
+      || state->sender_id != rtcm_2_sbp_sender_id(new_rtcm_obs->header.stn_id))) {
     // We either have missed a message, or we have a new station. Either way,
     // send through the current buffer and clear before adding new obs
     send_observations(state);
@@ -169,7 +175,7 @@ void add_obs_to_buffer(const rtcm_obs_message *new_rtcm_obs, gps_time_sec_t *obs
 
   // Copy new obs into buffer
   u8 obs_index_buffer = sbp_obs_buffer->header.n_obs;
-  state->sender_id = new_rtcm_obs->header.stn_id;
+  state->sender_id = rtcm_2_sbp_sender_id(new_rtcm_obs->header.stn_id);
   for(u8 obs_count = 0; obs_count < new_sbp_obs->header.n_obs; obs_count++) {
     sbp_obs_buffer->obs[obs_index_buffer] = new_sbp_obs->obs[obs_count];
     obs_index_buffer++;

--- a/c/tests/rtcm3_sbp_test.c
+++ b/c/tests/rtcm3_sbp_test.c
@@ -18,10 +18,11 @@
 
 #define MAX_FILE_SIZE 26000
 
-void sbp_callback (u8 msg_id, u8 length, u8 *buffer)
+void sbp_callback (u8 msg_id, u8 length, u8 *buffer, u16 sender_id)
 {
   (void) length;
   (void) buffer;
+  (void) sender_id;
   static uint32_t msg_count = 0;
   if(msg_count == 3 || msg_count == 19 || msg_count == 41) {
     assert(msg_id == SBP_MSG_BASE_POS_ECEF);


### PR DESCRIPTION
Currently, if we switch stations with the RTCM stream (for example with VRS) this wouldn't be captured in the sbp.