### PR TITLE
More rollover checking

### DIFF
--- a/haskell/src/Data/RTCM3/SBP/Time.hs
+++ b/haskell/src/Data/RTCM3/SBP/Time.hs
@@ -102,9 +102,10 @@ rolloverTowGpsTime tow t = t & gpsTimeNano_tow .~ tow & rollover
       | increment = gpsTimeNano_wn +~ 1
       | decrement = gpsTimeNano_wn +~ -1
       | otherwise = gpsTimeNano_wn +~ 0
-    diff      = fromIntegral tow - fromIntegral (t ^. gpsTimeNano_tow)
-    increment = diff < -weekMillis `div` 2
-    decrement = diff > weekMillis `div` 2
+    new       = fromIntegral tow
+    old       = fromIntegral (t ^. gpsTimeNano_tow)
+    increment = old > new && old - new > weekMillis `div` 2
+    decrement = new > old && new - old > weekMillis `div` 2
 
 -- | Update GPS time based on GLONASS epoch, handling week rollover.
 --
@@ -121,6 +122,6 @@ rolloverEpochGpsTime epoch t = rolloverTowGpsTime tow t
       | increment = dow + 1 `mod` 7
       | decrement = dow - 1 `mod` 7
       | otherwise = dow
-    increment = epoch'' - tod > dayMillis `div` 2
-    decrement = tod - epoch'' > dayMillis `div` 2
+    increment = epoch'' > tod && epoch'' - tod > dayMillis `div` 2
+    decrement = tod > epoch'' && tod - epoch'' > dayMillis `div` 2
     tow = fromIntegral $ dow' * dayMillis + epoch''

--- a/haskell/test/Test/Data/RTCM3/SBP/Time.hs
+++ b/haskell/test/Test/Data/RTCM3/SBP/Time.hs
@@ -14,12 +14,20 @@ import SwiftNav.SBP
 testRolloverGpsTime :: TestTree
 testRolloverGpsTime =
   testGroup "Rollover GPS time tests"
-    [ testCase "No rollover" $
-        rolloverTowGpsTime 510191000 (GpsTimeNano 510191000 0 1961) @?= (GpsTimeNano 510191000 0 1961)
-    , testCase "Positive rollover" $
-        rolloverTowGpsTime 0 (GpsTimeNano 604800000 0 1961) @?= (GpsTimeNano 0 0 1962)
-    , testCase "Negative rollover" $
+    [ testCase "No rollover" $ do
+        rolloverTowGpsTime 0 (GpsTimeNano 0 0 1960) @?= (GpsTimeNano 0 0 1960)
+        rolloverTowGpsTime 302400000 (GpsTimeNano 302400000 0 1960) @?= (GpsTimeNano 302400000 0 1960)
+        rolloverTowGpsTime 604800000 (GpsTimeNano 604800000 0 1960) @?= (GpsTimeNano 604800000 0 1960)
+        rolloverTowGpsTime 0 (GpsTimeNano 302400000 0 1960) @?= (GpsTimeNano 0 0 1960)
+        rolloverTowGpsTime 302400000 (GpsTimeNano 604800000 0 1960) @?= (GpsTimeNano 302400000 0 1960)
+    , testCase "Positive rollover" $ do
+        rolloverTowGpsTime 0 (GpsTimeNano 302400001 0 1960) @?= (GpsTimeNano 0 0 1961)
+        rolloverTowGpsTime 0 (GpsTimeNano 604800000 0 1960) @?= (GpsTimeNano 0 0 1961)
+        rolloverTowGpsTime 302399999 (GpsTimeNano 604800000 0 1960) @?= (GpsTimeNano 302399999 0 1961)
+    , testCase "Negative rollover" $ do
         rolloverTowGpsTime 604800000 (GpsTimeNano 0 0 1961) @?= (GpsTimeNano 604800000 0 1960)
+        rolloverTowGpsTime 604800000 (GpsTimeNano 302399999 0 1961) @?= (GpsTimeNano 604800000 0 1960)
+        rolloverTowGpsTime 302400001 (GpsTimeNano 0 0 1961) @?= (GpsTimeNano 302400001 0 1960)
     ]
 
 tests :: TestTree


### PR DESCRIPTION
Added some more coverage around tow rollover. Also changed up the rollover check a bit, following [rfc1982](https://tools.ietf.org/html/rfc1982#section-3.2). Seems simpler to process. Also on the GLONASS rollover it ensures we're doing the right subtraction (weren't checking before).

/cc @anth-cole 