### PR TITLE
Debug crash

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.7)
 project(gnss-convertors)
 
 # Some compiler options used globally
-set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-strict-prototypes -Werror -std=gnu99 -fno-unwind-tables -fno-asynchronous-unwind-tables -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security ${CMAKE_C_FLAGS}")
+set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-strict-prototypes -Werror -std=gnu99 -fno-unwind-tables -fno-asynchronous-unwind-tables -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security -ggdb ${CMAKE_C_FLAGS}")
 
 IF (EXISTS ${CMAKE_SOURCE_DIR}/librtcm/c)
     add_subdirectory (librtcm/c)

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -200,9 +200,9 @@ void send_observations(struct rtcm3_sbp_state *state)
   const msg_obs_t *sbp_obs_buffer = (msg_obs_t *)state->obs_buffer;
 
   /* Work out how many sbp messages we need to split this into */
-  const ssize_t header_size = sizeof(observation_header_t);
-  const ssize_t obs_size = sizeof(packed_obs_content_t);
-  const ssize_t max_obs_in_sbp = ((MAX_SBP_PAYLOAD - header_size) / obs_size);
+  const uint32_t header_size = sizeof(observation_header_t);
+  const uint32_t obs_size = sizeof(packed_obs_content_t);
+  const uint32_t max_obs_in_sbp = ((MAX_SBP_PAYLOAD - header_size) / obs_size);
 
   /* We want the ceiling of n_obs divided by max obs in a single message to get
    * total number of messages needed */

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -199,40 +199,35 @@ void send_observations(struct rtcm3_sbp_state *state)
 {
   const msg_obs_t *sbp_obs_buffer = (msg_obs_t *)state->obs_buffer;
 
-  u8 obs_count = 0;
-  u8 sizes[4];
+  /* Work out how many sbp messages we need to split this into */
   uint32_t header_size = sizeof(observation_header_t);
   uint32_t obs_size = sizeof(packed_obs_content_t);
-  u8 obs_data[4 * header_size + 4 * sbp_obs_buffer->header.n_obs * obs_size];
-  msg_obs_t *sbp_obs[4];
   uint32_t max_obs_in_sbp = ((MAX_SBP_PAYLOAD - header_size) / obs_size);
 
-  u8 total_messages = 0;
-  u8 msg_num = 0;
-  for (msg_num = 0; msg_num < 4; ++msg_num) {
-    sbp_obs[msg_num] =
-      (msg_obs_t * )(obs_data + (msg_num * header_size +
-        max_obs_in_sbp * msg_num * obs_size));
+  /* We want the ceiling of n_obs divided by max obs in a single message to get
+   * total number of messages needed */
+  u8 total_messages = 1 + ((sbp_obs_buffer->header.n_obs - 1) / max_obs_in_sbp);
 
-    sbp_obs[msg_num]->header.t = sbp_obs_buffer->header.t;
-    sbp_obs[msg_num]->header.n_obs = 0;
+  u8 obs_count = 0;
+  uint32_t buffer_size = header_size + sbp_obs_buffer->header.n_obs * obs_size;
+  u8 obs_data[buffer_size];
+  msg_obs_t *sbp_obs = (msg_obs_t*)obs_data;
+
+  for (u8 msg_num = 0; msg_num < total_messages; ++msg_num) {
+    memset(obs_data,0,buffer_size);
+
+    sbp_obs->header.t = sbp_obs_buffer->header.t;
 
     u8 obs_index;
     for (obs_index = 0; obs_index < max_obs_in_sbp && obs_count < sbp_obs_buffer->header.n_obs; obs_index++) {
-      sbp_obs[msg_num]->obs[obs_index] = sbp_obs_buffer->obs[obs_count++];
+      sbp_obs->obs[obs_index] = sbp_obs_buffer->obs[obs_count++];
     }
 
-    if(obs_index > 0) {
-      total_messages++;
-    }
-    sizes[msg_num] = header_size + obs_index * obs_size;
-  }
+    u8 size = header_size + obs_index * obs_size;
+    sbp_obs->header.n_obs = (total_messages << 4) + msg_num;
 
-  for (u8 msg = 0; msg < total_messages; ++msg) {
-    sbp_obs[msg]->header.n_obs = (total_messages << 4) + msg;
-    state->cb(SBP_MSG_OBS, sizes[msg], (u8 *) sbp_obs[msg], state->sender_id);
+    state->cb(SBP_MSG_OBS, size, (u8 *) sbp_obs, state->sender_id);
   }
-
   memset((void*)sbp_obs_buffer,0, sizeof(*sbp_obs_buffer));
 }
 

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -200,33 +200,30 @@ void send_observations(struct rtcm3_sbp_state *state)
   const msg_obs_t *sbp_obs_buffer = (msg_obs_t *)state->obs_buffer;
 
   /* Work out how many sbp messages we need to split this into */
-  uint32_t header_size = sizeof(observation_header_t);
-  uint32_t obs_size = sizeof(packed_obs_content_t);
-  uint32_t max_obs_in_sbp = ((MAX_SBP_PAYLOAD - header_size) / obs_size);
+  const ssize_t header_size = sizeof(observation_header_t);
+  const ssize_t obs_size = sizeof(packed_obs_content_t);
+  const ssize_t max_obs_in_sbp = ((MAX_SBP_PAYLOAD - header_size) / obs_size);
 
   /* We want the ceiling of n_obs divided by max obs in a single message to get
    * total number of messages needed */
-  u8 total_messages = 1 + ((sbp_obs_buffer->header.n_obs - 1) / max_obs_in_sbp);
+  const u8 total_messages = 1 + ((sbp_obs_buffer->header.n_obs - 1) / max_obs_in_sbp);
 
   u8 obs_count = 0;
-  uint32_t buffer_size = header_size + sbp_obs_buffer->header.n_obs * obs_size;
-  u8 obs_data[buffer_size];
+  u8 obs_data[MAX_SBP_PAYLOAD];
   msg_obs_t *sbp_obs = (msg_obs_t*)obs_data;
 
   for (u8 msg_num = 0; msg_num < total_messages; ++msg_num) {
-    memset(obs_data,0,buffer_size);
+    memset(obs_data,0,MAX_SBP_PAYLOAD);
 
-    sbp_obs->header.t = sbp_obs_buffer->header.t;
-
-    u8 obs_index;
-    for (obs_index = 0; obs_index < max_obs_in_sbp && obs_count < sbp_obs_buffer->header.n_obs; obs_index++) {
-      sbp_obs->obs[obs_index] = sbp_obs_buffer->obs[obs_count++];
+    u8 obs_index = 0;
+    while (obs_index < max_obs_in_sbp && obs_count < sbp_obs_buffer->header.n_obs) {
+      sbp_obs->obs[obs_index++] = sbp_obs_buffer->obs[obs_count++];
     }
 
-    u8 size = header_size + obs_index * obs_size;
+    sbp_obs->header.t = sbp_obs_buffer->header.t;
     sbp_obs->header.n_obs = (total_messages << 4) + msg_num;
 
-    state->cb(SBP_MSG_OBS, size, (u8 *) sbp_obs, state->sender_id);
+    state->cb(SBP_MSG_OBS, header_size + obs_index * obs_size, (u8 *) sbp_obs, state->sender_id);
   }
   memset((void*)sbp_obs_buffer,0, sizeof(*sbp_obs_buffer));
 }


### PR DESCRIPTION
This PR address the issue where the sbp_rtcm3_bridge package would crash on the piksi periodically, typically on GPS+GLO stations, but also sometimes on GPS only messages.

What I know about the crash from debugging on piksi with gdb
- It happened the 3 times I caught it when 10 obs were transmitted
- This then was a GPS only epoch
- It happened on line 232 (`sbp_obs[msg]->header.n_obs = (total_messages << 4) + msg;`) when we tried to dereference the pointer `sbp_obs[msg]`
- Putting asserts to check the pointer validity passed right up to the line immediately before line 232

I believe this might be something to do with the way the arm can only access aligned memory, but no idea what that could be as in the debugged case the sbp message should be at the start of the allocation buffer. The change is to essentially allocate one SBP message's worth of room and reuse this for each SBP message constructed.

I've currently been running for 8 hours with no crash, I'll let it go for 24 on OXMT and if no crashes I'll put this in.

@mfine @peddie 