### PR TITLE
Reject any RTCM obs that have the same timestamp as one already received

### DIFF
--- a/c/include/rtcm3_sbp.h
+++ b/c/include/rtcm3_sbp.h
@@ -18,7 +18,7 @@
 
 #define MAX_OBS_PER_EPOCH 56
 /* MAX valid value (ms) for GPS is 604799999 and GLO is 86401999 */
-#define INVALID_TOW 0xFFFF
+#define INVALID_TIME 0xFFFF
 
 struct rtcm3_sbp_state {
   gps_time_sec_t time_from_rover_obs;
@@ -26,8 +26,8 @@ struct rtcm3_sbp_state {
   s8 leap_seconds;
   bool leap_second_known;
   u16 sender_id;
-  u32 last_gps_time;
-  u32 last_glo_time;
+  gps_time_sec_t last_gps_time;
+  gps_time_sec_t last_glo_time;
   void (*cb)(u8 msg_id, u8 buff, u8 *len, u16 sender_id);
   u8 obs_buffer[sizeof(observation_header_t) + MAX_OBS_PER_EPOCH * sizeof(packed_obs_content_t)];
 };

--- a/c/include/rtcm3_sbp.h
+++ b/c/include/rtcm3_sbp.h
@@ -17,6 +17,8 @@
 #include <libsbp/gnss.h>
 
 #define MAX_OBS_PER_EPOCH 56
+/* MAX valid value (ms) for GPS is 604799999 and GLO is 86401999 */
+#define INVALID_TOW 0xFFFF
 
 struct rtcm3_sbp_state {
   gps_time_sec_t time_from_rover_obs;
@@ -24,6 +26,8 @@ struct rtcm3_sbp_state {
   s8 leap_seconds;
   bool leap_second_known;
   u16 sender_id;
+  u32 last_gps_time;
+  u32 last_glo_time;
   void (*cb)(u8 msg_id, u8 buff, u8 *len, u16 sender_id);
   u8 obs_buffer[sizeof(observation_header_t) + MAX_OBS_PER_EPOCH * sizeof(packed_obs_content_t)];
 };

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -15,11 +15,6 @@
 #include <math.h>
 #include <string.h>
 #include <assert.h>
-#include <rtcm3_messages.h>
-#include <libsbp/gnss.h>
-
-uint32_t last_gps_obs_time;
-uint32_t last_glo_obs_time;
 
 void rtcm2sbp_init(struct rtcm3_sbp_state *state,
                    void (*cb)(u8 msg_id, u8 length, u8 *buffer, u16 sender_id))


### PR DESCRIPTION
This keeps track of the last timestamp of the RTCM obs received and doesn't accept following RTCM obs messages of same or different type that have the same timestamp.

This is a problem if we get a stream with 1002 and 1004 messages, that are the L1 only and L1/L2 RTCM messages. While this is not a valid input stream, this will crash the receiver currently, this handles the situation more gracefully by ignoring any subsequent messages with identical RTCM time of week.