### PR TITLE
Add sanity check for base observations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 *.*DS_Store
 build*/
 .idea/
+.stamp*
+.applied_patches_list
+.br_*
+CMakeFiles
+CMakeCache.txt
+.*.swp

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -1,0 +1,3 @@
+Makefile
+cmake_install.cmake
+install_manifest.txt

--- a/c/include/rtcm3_sbp.h
+++ b/c/include/rtcm3_sbp.h
@@ -28,7 +28,7 @@ struct rtcm3_sbp_state {
   u16 sender_id;
   gps_time_sec_t last_gps_time;
   gps_time_sec_t last_glo_time;
-  void (*cb)(u8 msg_id, u8 buff, u8 *len, u16 sender_id);
+  void (*cb_rtcm_to_sbp)(u8 msg_id, u8 buff, u8 *len, u16 sender_id);
   void (*cb_base_obs_invalid)(double time_diff);
   u8 obs_buffer[sizeof(observation_header_t) + MAX_OBS_PER_EPOCH * sizeof(packed_obs_content_t)];
 };
@@ -40,7 +40,7 @@ void rtcm2sbp_set_gps_time(gps_time_sec_t *current_time, struct rtcm3_sbp_state*
 void rtcm2sbp_set_leap_second(s8 leap_seconds, struct rtcm3_sbp_state *state);
 
 void rtcm2sbp_init(struct rtcm3_sbp_state *state,
-                   void (*cb)(u8 msg_id, u8 length, u8 *buffer, u16 sender_id),
+                   void (*cb_rtcm_to_sbp)(u8 msg_id, u8 length, u8 *buffer, u16 sender_id),
                    void (*cb_base_obs_invalid)(double time_diff));
 
 #endif //GNSS_CONVERTERS_RTCM3_SBP_INTERFACE_H

--- a/c/include/rtcm3_sbp.h
+++ b/c/include/rtcm3_sbp.h
@@ -29,6 +29,7 @@ struct rtcm3_sbp_state {
   gps_time_sec_t last_gps_time;
   gps_time_sec_t last_glo_time;
   void (*cb)(u8 msg_id, u8 buff, u8 *len, u16 sender_id);
+  void (*cb_base_obs_invalid)(double time_diff);
   u8 obs_buffer[sizeof(observation_header_t) + MAX_OBS_PER_EPOCH * sizeof(packed_obs_content_t)];
 };
 
@@ -39,6 +40,7 @@ void rtcm2sbp_set_gps_time(gps_time_sec_t *current_time, struct rtcm3_sbp_state*
 void rtcm2sbp_set_leap_second(s8 leap_seconds, struct rtcm3_sbp_state *state);
 
 void rtcm2sbp_init(struct rtcm3_sbp_state *state,
-                   void (*cb)(u8 msg_id, u8 length, u8 *buffer, u16 sender_id));
+                   void (*cb)(u8 msg_id, u8 length, u8 *buffer, u16 sender_id),
+                   void (*cb_base_obs_invalid)(double time_diff));
 
 #endif //GNSS_CONVERTERS_RTCM3_SBP_INTERFACE_H

--- a/c/src/rtcm3_sbp_internal.h
+++ b/c/src/rtcm3_sbp_internal.h
@@ -16,8 +16,6 @@
 #include <rtcm3_messages.h>
 #include <rtcm3_sbp.h>
 
-#include <libsbp/piksi.h>
-
 #define MSG_OBS_P_MULTIPLIER ((double)5e1)
 #define MSG_OBS_CN0_MULTIPLIER ((float)4)
 #define MSG_OBS_LF_MULTIPLIER ((double)(1 << 8))

--- a/c/src/rtcm3_sbp_internal.h
+++ b/c/src/rtcm3_sbp_internal.h
@@ -16,6 +16,8 @@
 #include <rtcm3_messages.h>
 #include <rtcm3_sbp.h>
 
+#include <libsbp/piksi.h>
+
 #define MSG_OBS_P_MULTIPLIER ((double)5e1)
 #define MSG_OBS_CN0_MULTIPLIER ((float)4)
 #define MSG_OBS_LF_MULTIPLIER ((double)(1 << 8))
@@ -80,7 +82,8 @@ void add_obs_to_buffer(const rtcm_obs_message *new_rtcm_obs,
                        gps_time_sec_t *new_sbp_obs, struct rtcm3_sbp_state *state);
 
 void compute_gps_time(double tow_ms, gps_time_sec_t *new_sbp_obs,
-                      const gps_time_sec_t *rover_time);
+                      const gps_time_sec_t *rover_time,
+                      struct rtcm3_sbp_state *state);
 
 void compute_glo_time(double tod_ms, gps_time_sec_t *obs_time,
                       const gps_time_sec_t *rover_time, const s8 leap_second);

--- a/c/tests/rtcm3_sbp_test.c
+++ b/c/tests/rtcm3_sbp_test.c
@@ -60,7 +60,7 @@ void test_RTCM3_decode(void)
 {
   // This file is GPS only and tests basic decoding functionality
   struct rtcm3_sbp_state state;
-  rtcm2sbp_init(&state, sbp_callback_gps);
+  rtcm2sbp_init(&state, sbp_callback_gps, NULL);
   gps_time_sec_t current_time;
   current_time.wn = 1945;
   current_time.tow = 277500;
@@ -96,7 +96,7 @@ void test_day_rollover(void)
   // GPS GLO decoding functionality and time matching
 
   struct rtcm3_sbp_state state;
-  rtcm2sbp_init(&state, sbp_callback_glo_day_rollover);
+  rtcm2sbp_init(&state, sbp_callback_glo_day_rollover, NULL);
   gps_time_sec_t current_time;
   current_time.wn = 1959;
   current_time.tow = 510191;


### PR DESCRIPTION
If the base observations start getting too old to be used (> 10s) --
invoke an (optionally provided) callback to indicate this.