### PR TITLE
Convert GLO ephemeris to SBP

### DIFF
--- a/haskell/src/Data/RTCM3/SBP.hs
+++ b/haskell/src/Data/RTCM3/SBP.hs
@@ -41,7 +41,8 @@ converter = \case
   (RTCM3Msg1012 m _rtcm3) -> Observations.converter m
   (RTCM3Msg1005 m _rtcm3) -> Positions.converter m
   (RTCM3Msg1006 m _rtcm3) -> Positions.converter m
-  (RTCM3Msg1019 m _rtcm3) -> Ephemerides.converter m
+  (RTCM3Msg1019 m _rtcm3) -> Ephemerides.gpsConverter m
+  (RTCM3Msg1020 m _rtcm3) -> Ephemerides.glonassConverter m
   (RTCM3Msg1230 m _rtcm3) -> Biases.converter m
   _rtcm3Msg               -> mempty
 

--- a/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
+++ b/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
@@ -121,7 +121,7 @@ glonassFitInterval fi
   | fi == 1 = 30 * 60
   | fi == 2 = 45 * 60
   | fi == 3 = 60 * 60
-  | otherwise = 60 * 60 -- ?? TODO: GOOD IDEA? WHAT'S A GOOD DEFAULT?
+  | otherwise = 60 * 60
 
 -- | Construct an EphemerisCommonContent from an RTCM 1019 message.
 --
@@ -207,7 +207,7 @@ glonassConverter m = do
              { _msgEphemerisGlo_common = common
              , _msgEphemerisGlo_gamma  = (-40) ## (m ^. msg1020_ephemeris ^. glonassEphemeris_gammaN)
              , _msgEphemerisGlo_tau    = (-30) ## (m ^. msg1020_ephemeris ^. glonassEphemeris_tauN)
-             , _msgEphemerisGlo_d_tau  = undefined -- TODO: equipment delay between L1 and L2??
+             , _msgEphemerisGlo_d_tau  = (-30) ## (m ^. msg1020_ephemeris ^. glonassEphemeris_mdeltatau)
              , _msgEphemerisGlo_pos    = (* 1000) . ((-11) ##) <$>
                  [ m ^. msg1020_ephemeris ^. glonassEphemeris_xn
                  , m ^. msg1020_ephemeris ^. glonassEphemeris_yn
@@ -223,7 +223,7 @@ glonassConverter m = do
                  , m ^. msg1020_ephemeris ^. glonassEphemeris_yndotdot
                  , m ^. msg1020_ephemeris ^. glonassEphemeris_zndotdot
                  ]
-             , _msgEphemerisGlo_fcn    = m ^. msg1020_header ^. glonassEphemerisHeader_channel -- TODO: docs say FCN+8???
-             , _msgEphemerisGlo_iod    = undefined -- TODO: ??? Issue of ephemeris data??
+             , _msgEphemerisGlo_fcn    = (m ^. msg1020_header ^. glonassEphemerisHeader_channel) + 1
+             , _msgEphemerisGlo_iod    = ((m ^. msg1020_ephemeris ^. glonassEphemeris_tb) * 15 * 60) .&. 127
              }
   yield [SBPMsgEphemerisGlo m' $ toSBP m' 61440]

--- a/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
+++ b/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
@@ -172,30 +172,30 @@ gpsConverter m = do
   toc    <- toGpsTimeSec (m ^. msg1019_ephemeris ^. gpsEphemeris_wn) (m ^. msg1019_ephemeris ^. gpsEphemeris_toc)
   let pi' = 3.1415926535898
       m'  = MsgEphemerisGps
-                 { _msgEphemerisGps_common   = common
-                 , _msgEphemerisGps_tgd      =       (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_tgd)
-                 , _msgEphemerisGps_c_rs     =        (-5) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_rs)
-                 , _msgEphemerisGps_c_rc     =        (-5) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_rc)
-                 , _msgEphemerisGps_c_uc     =       (-29) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_uc)
-                 , _msgEphemerisGps_c_us     =       (-29) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_us)
-                 , _msgEphemerisGps_c_ic     =       (-29) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_ic)
-                 , _msgEphemerisGps_c_is     =       (-29) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_is)
-                 , _msgEphemerisGps_dn       = pi' * (-43) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_dn)
-                 , _msgEphemerisGps_m0       = pi' * (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_m0)
-                 , _msgEphemerisGps_ecc      =       (-33) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_ecc)
-                 , _msgEphemerisGps_sqrta    =       (-19) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_sqrta)
-                 , _msgEphemerisGps_omega0   = pi' * (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_omega0)
-                 , _msgEphemerisGps_omegadot = pi' * (-43) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_omegadot)
-                 , _msgEphemerisGps_w        = pi' * (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_w)
-                 , _msgEphemerisGps_inc      = pi' * (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_i0)
-                 , _msgEphemerisGps_inc_dot  = pi' * (-43) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_idot)
-                 , _msgEphemerisGps_af0      =       (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_af0)
-                 , _msgEphemerisGps_af1      =       (-43) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_af1)
-                 , _msgEphemerisGps_af2      =       (-55) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_af2)
-                 , _msgEphemerisGps_iodc     =                 m ^. msg1019_ephemeris ^. gpsEphemeris_iodc
-                 , _msgEphemerisGps_iode     =                 m ^. msg1019_ephemeris ^. gpsEphemeris_iode
-                 , _msgEphemerisGps_toc      = toc
-                 }
+              { _msgEphemerisGps_common   = common
+              , _msgEphemerisGps_tgd      =       (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_tgd)
+              , _msgEphemerisGps_c_rs     =        (-5) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_rs)
+              , _msgEphemerisGps_c_rc     =        (-5) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_rc)
+              , _msgEphemerisGps_c_uc     =       (-29) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_uc)
+              , _msgEphemerisGps_c_us     =       (-29) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_us)
+              , _msgEphemerisGps_c_ic     =       (-29) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_ic)
+              , _msgEphemerisGps_c_is     =       (-29) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_c_is)
+              , _msgEphemerisGps_dn       = pi' * (-43) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_dn)
+              , _msgEphemerisGps_m0       = pi' * (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_m0)
+              , _msgEphemerisGps_ecc      =       (-33) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_ecc)
+              , _msgEphemerisGps_sqrta    =       (-19) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_sqrta)
+              , _msgEphemerisGps_omega0   = pi' * (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_omega0)
+              , _msgEphemerisGps_omegadot = pi' * (-43) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_omegadot)
+              , _msgEphemerisGps_w        = pi' * (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_w)
+              , _msgEphemerisGps_inc      = pi' * (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_i0)
+              , _msgEphemerisGps_inc_dot  = pi' * (-43) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_idot)
+              , _msgEphemerisGps_af0      =       (-31) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_af0)
+              , _msgEphemerisGps_af1      =       (-43) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_af1)
+              , _msgEphemerisGps_af2      =       (-55) ## (m ^. msg1019_ephemeris ^. gpsEphemeris_af2)
+              , _msgEphemerisGps_iodc     =                 m ^. msg1019_ephemeris ^. gpsEphemeris_iodc
+              , _msgEphemerisGps_iode     =                 m ^. msg1019_ephemeris ^. gpsEphemeris_iode
+              , _msgEphemerisGps_toc      = toc
+              }
   yield [SBPMsgEphemerisGps m' $ toSBP m' 61440]
 
 -- | Convert an RTCM 1020 GLONASS ephemeris message into an SBP MsgEphemerisGlo.

--- a/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
+++ b/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
@@ -223,7 +223,7 @@ glonassConverter m = do
                  , m ^. msg1020_ephemeris ^. glonassEphemeris_yndotdot
                  , m ^. msg1020_ephemeris ^. glonassEphemeris_zndotdot
                  ]
-             , _msgEphemerisGlo_fcn    = undefined -- TODO
-             , _msgEphemerisGlo_iod    = undefined -- TODO:
+             , _msgEphemerisGlo_fcn    = m ^. msg1020_header ^. glonassEphemerisHeader_channel -- TODO: docs say FCN+8???
+             , _msgEphemerisGlo_iod    = undefined -- TODO: ??? Issue of ephemeris data??
              }
   yield [SBPMsgEphemerisGlo m' $ toSBP m' 61440]

--- a/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
+++ b/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
@@ -153,7 +153,7 @@ toGlonassEphemerisCommonContent m = do
     , _ephemerisCommonContent_toe          = toe
     , _ephemerisCommonContent_ura          = ftToUra (m ^. msg1020_ephemeris ^. glonassEphemeris_mft)
     , _ephemerisCommonContent_fit_interval = glonassFitInterval (m ^. msg1020_ephemeris ^. glonassEphemeris_p1)
-    , _ephemerisCommonContent_valid        = bool 0 1 $ (m ^. msg1020_ephemeris ^. glonassEphemeris_healthAvailability) && (m ^. msg1020_ephemeris ^. glonassEphemeris_almanacHealth) && (m ^. msg1020_ephemeris ^. glonassEphemeris_bn_msb)
+    , _ephemerisCommonContent_valid        = 1
     , _ephemerisCommonContent_health_bits  = bool 0 1 $ (m ^. msg1020_ephemeris ^. glonassEphemeris_mln5) || (m ^. msg1020_ephemeris ^. glonassEphemeris_mi3)
     }
 

--- a/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
+++ b/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
@@ -46,7 +46,7 @@ toGlonassTimeSec :: MonadStore e m => Word8 -> m GpsTimeSec
 toGlonassTimeSec epoch = do
   time <- view storeCurrentGpsTime
   t    <- liftIO time
-  let epoch' = fromIntegral epoch * 15 - 3 * hourMillis + gpsLeapMillis
+  let epoch' = fromIntegral epoch * 15 * minuteMillis - 3 * hourMillis + gpsLeapMillis
       epoch''
         | epoch' < 0 = epoch' + dayMillis
         | otherwise = epoch'

--- a/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
+++ b/haskell/src/Data/RTCM3/SBP/Ephemerides.hs
@@ -117,11 +117,11 @@ gpsFitInterval fitInt iodc
 --
 glonassFitInterval :: Word8 -> Word32
 glonassFitInterval fi
-  | fi == 0 = 0
-  | fi == 1 = 30 * 60
-  | fi == 2 = 45 * 60
-  | fi == 3 = 60 * 60
-  | otherwise = 60 * 60
+  | fi == 0 = (60 + 10) * 60
+  | fi == 1 = (30 + 10) * 60
+  | fi == 2 = (45 + 10) * 60
+  | fi == 3 = (60 + 10) * 60
+  | otherwise = (60 + 10) * 60
 
 -- | Construct an EphemerisCommonContent from an RTCM 1019 message.
 --

--- a/haskell/src/Data/RTCM3/SBP/Time.hs
+++ b/haskell/src/Data/RTCM3/SBP/Time.hs
@@ -13,6 +13,7 @@
 
 module Data.RTCM3.SBP.Time
   ( gpsLeapMillis
+  , minuteMillis
   , hourMillis
   , dayMillis
   , weekMillis
@@ -45,6 +46,16 @@ gpsLeapSeconds = 18
 --
 gpsLeapMillis :: Integer
 gpsLeapMillis = 1000 * gpsLeapSeconds
+
+-- | Minute seconds
+--
+minuteSeconds :: Integer
+minuteSeconds = 60
+
+-- | Minute milliseconds
+--
+minuteMillis :: Integer
+minuteMillis = 1000 * minuteSeconds
 
 -- | Hour seconds
 --


### PR DESCRIPTION
Based on [peddie/glonass](https://github.com/swift-nav/gnss-converters/compare/peddie/glonass).

Converts GLO ephemerides messages in RTCM to SBP.

/cc @peddie @anth-cole @benjamin0 