### PR TITLE
Log RTCM Message Type 1029 Manually as SBP_MSG_LOG

### DIFF
--- a/c/include/rtcm3_sbp.h
+++ b/c/include/rtcm3_sbp.h
@@ -29,7 +29,7 @@ struct rtcm3_sbp_state {
   gps_time_sec_t last_gps_time;
   gps_time_sec_t last_glo_time;
   gps_time_sec_t last_1230_received;
-  void (*cb_rtcm_to_sbp)(u8 msg_id, u8 buff, u8 *len, u16 sender_id);
+  void (*cb_rtcm_to_sbp)(u16 msg_id, u8 buff, u8 *len, u16 sender_id);
   void (*cb_base_obs_invalid)(double time_diff);
   u8 obs_buffer[sizeof(observation_header_t) +
                 MAX_OBS_PER_EPOCH * sizeof(packed_obs_content_t)];
@@ -44,7 +44,7 @@ void rtcm2sbp_set_gps_time(gps_time_sec_t *current_time,
 void rtcm2sbp_set_leap_second(s8 leap_seconds, struct rtcm3_sbp_state *state);
 
 void rtcm2sbp_init(struct rtcm3_sbp_state *state,
-                   void (*cb_rtcm_to_sbp)(u8 msg_id, u8 length, u8 *buffer,
+                   void (*cb_rtcm_to_sbp)(u16 msg_id, u8 length, u8 *buffer,
                                           u16 sender_id),
                    void (*cb_base_obs_invalid)(double time_diff));
 

--- a/c/include/rtcm3_sbp.h
+++ b/c/include/rtcm3_sbp.h
@@ -15,6 +15,7 @@
 
 #include <libsbp/gnss.h>
 #include <libsbp/observation.h>
+#include <libsbp/logging.h>
 
 #define MAX_OBS_PER_EPOCH 56
 /* MAX valid value (ms) for GPS is 604799999 and GLO is 86401999 */

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -139,8 +139,6 @@ void rtcm2sbp_decode_frame(const uint8_t *frame, uint32_t frame_length,
     }
     break;
   }
-#define SBP_FRAMING_MAX_PAYLOAD_SIZE (255u)
-#define RTCM_1029_LOGGING_LEVEL (6u)  // This represents LOG_INFO
   case 1029: {
     rtcm_msg_1029 msg_1029;
     if (rtcm3_decode_1029(&frame[byte], &msg_1029) == 0) {
@@ -621,6 +619,8 @@ bool no_1230_received(struct rtcm3_sbp_state *state) {
   return false;
 }
 
+#define SBP_FRAMING_MAX_PAYLOAD_SIZE (255u)
+#define RTCM_1029_LOGGING_LEVEL (6u)  // This represents LOG_INFO
 void send_1029(rtcm_msg_1029 *msg_1029, struct rtcm3_sbp_state *state){
   u8 text_size = sizeof(msg_log_t) + msg_1029->utf8_code_units_n > SBP_FRAMING_MAX_PAYLOAD_SIZE ?
                  SBP_FRAMING_MAX_PAYLOAD_SIZE - sizeof(msg_log_t) :

--- a/c/src/rtcm3_sbp_internal.h
+++ b/c/src/rtcm3_sbp_internal.h
@@ -118,4 +118,8 @@ void send_observations(struct rtcm3_sbp_state *state);
 
 bool no_1230_received(struct rtcm3_sbp_state *state);
 
+void send_1029(rtcm_msg_1029 *msg_1029, struct rtcm3_sbp_state *state);
+
+void send_sbp_log_message(const uint8_t level, const uint8_t* message, const uint8_t length, const uint16_t stn_id, struct rtcm3_sbp_state *state);
+
 #endif // GNSS_CONVERTERS_RTCM3_SBP_H

--- a/c/tests/rtcm3_sbp_test.c
+++ b/c/tests/rtcm3_sbp_test.c
@@ -18,7 +18,7 @@
 
 #define MAX_FILE_SIZE 26000
 
-void sbp_callback_gps(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
+void sbp_callback_gps(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   (void)length;
   (void)buffer;
   (void)sender_id;
@@ -33,7 +33,7 @@ void sbp_callback_gps(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   msg_count++;
 }
 
-void sbp_callback_glo_day_rollover(u8 msg_id, u8 length, u8 *buffer,
+void sbp_callback_glo_day_rollover(u16 msg_id, u8 length, u8 *buffer,
                                    u16 sender_id) {
   (void)length;
   (void)buffer;
@@ -63,7 +63,7 @@ void check_biases(msg_glo_biases_t *sbp_glo_msg, double l1ca_bias,
   }
 }
 
-void sbp_callback_trimble(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
+void sbp_callback_trimble(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   (void)length;
   (void)sender_id;
   if (msg_id == SBP_MSG_GLO_BIASES) {
@@ -73,7 +73,7 @@ void sbp_callback_trimble(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   }
 }
 
-void sbp_callback_sept(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
+void sbp_callback_sept(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   (void)length;
   (void)sender_id;
   if (msg_id == SBP_MSG_GLO_BIASES) {
@@ -83,7 +83,7 @@ void sbp_callback_sept(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   }
 }
 
-void sbp_callback_javad(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
+void sbp_callback_javad(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   (void)length;
   (void)sender_id;
   if (msg_id == SBP_MSG_GLO_BIASES) {
@@ -92,7 +92,7 @@ void sbp_callback_javad(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   }
 }
 
-void sbp_callback_leica(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
+void sbp_callback_leica(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   (void)length;
   (void)sender_id;
   if (msg_id == SBP_MSG_GLO_BIASES) {
@@ -102,7 +102,7 @@ void sbp_callback_leica(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   }
 }
 
-void sbp_callback_navcom(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
+void sbp_callback_navcom(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   (void)length;
   (void)sender_id;
   if (msg_id == SBP_MSG_GLO_BIASES) {
@@ -111,7 +111,7 @@ void sbp_callback_navcom(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   }
 }
 
-void sbp_callback_topcon(u8 msg_id, u8 length, u8 *buffer, u16 sender_id) {
+void sbp_callback_topcon(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   (void)length;
   (void)sender_id;
   if (msg_id == SBP_MSG_GLO_BIASES) {


### PR DESCRIPTION
Addressing swift-nav/piksi_v3_bug_tracking#921, and downstream on the changed supplied by PR https://github.com/swift-nav/librtcm/pull/30, this PR covers handling the RTCM 1029 message in `rtcm2sbp_decode_frame`. The current strategy is to place the content of the 1029 (unicode text string) directly into an sbp log message and use the sbp callback to emit the message onto the bus. 

Details:

 * Protoype for sbp callback was updated to reflect being a u16 (SBP_MSG_LOG > 255)
 * Temporarily checked librtcm out to https://github.com/swift-nav/librtcm/pull/30 this will be updated after that PR is merged to master (how do we normally handle dependecies like this?)
 * The max framing size for an sbp message and the max size of the unicode buffer supplied by the 1029 are the same, but the inclusion of the sbp log level effective truncates the 1029 range to 254. I've added a check for this but it's rather minimal and would not cover inspection of the unicode string to remove a full unicode character. May need to add as issue.