### PR TITLE
Add more range checks to satellite IDs and GLONASS FCNs

### DIFF
--- a/haskell/src/Data/RTCM3/SBP/MSM.hs
+++ b/haskell/src/Data/RTCM3/SBP/MSM.hs
@@ -46,9 +46,16 @@ toCells hdr =
       sig <- mask (hdr ^. msmHeader_signalMask)
       pure (sat, sig)
 
+
+-- | Max GPS satellite number.
+--
+gpsMaxSat :: Word8
+gpsMaxSat = 32
+
 toGpsSat :: Word8 -> Maybe Word8
 toGpsSat sat
-  | sat >= 64 = Nothing
+  | sat < 1 = Nothing
+  | sat > gpsMaxSat = Nothing
   | otherwise = Just sat
 
 toGpsCode :: Word8 -> Maybe Word8

--- a/haskell/src/Data/RTCM3/SBP/Observations.hs
+++ b/haskell/src/Data/RTCM3/SBP/Observations.hs
@@ -182,7 +182,7 @@ toGpsL1PackedObsContents sat l1o l1eo
       , _packedObsContent_flags = obsFlags
       }
   where
-    no = sat > gpsMaxSat || l1o ^. gpsL1Observation_pseudorange == 524288 || l1o ^. gpsL1Observation_carrierMinusCode == -524288
+    no = sat < 1 || sat > gpsMaxSat || l1o ^. gpsL1Observation_pseudorange == 524288 || l1o ^. gpsL1Observation_carrierMinusCode == -524288
     p1 = pseudorange gpsPseudorange (l1o ^. gpsL1Observation_pseudorange) (l1eo ^. gpsL1ExtObservation_ambiguity)
     l1 = carrierPhase gpsL1CarrierPhase p1 (l1o ^. gpsL1Observation_carrierMinusCode)
 
@@ -201,7 +201,7 @@ toGpsL2PackedObsContents sat l1o l1eo l2o l2eo
       , _packedObsContent_flags = obsFlags
       }
   where
-    no = sat > gpsMaxSat || l2o ^. gpsL2Observation_pseudorangeDifference == -8192 || l2o ^. gpsL2Observation_carrierMinusCode == -524288
+    no = sat < 1 || sat > gpsMaxSat || l2o ^. gpsL2Observation_pseudorangeDifference == -8192 || l2o ^. gpsL2Observation_carrierMinusCode == -524288
     p1 = pseudorange gpsPseudorange (l1o ^. gpsL1Observation_pseudorange) (l1eo ^. gpsL1ExtObservation_ambiguity)
     p2 = p1 + pseudorangeDifference (l2o ^. gpsL2Observation_pseudorangeDifference)
     l2 = carrierPhase gpsL2CarrierPhase p1 (l2o ^. gpsL2Observation_carrierMinusCode)
@@ -222,7 +222,7 @@ toGlonassL1PackedObsContents sat l1o l1eo
         , _packedObsContent_flags = obsFlags
         }
   where
-    no = sat > glonassMaxSat || l1o ^. glonassL1Observation_carrierMinusCode == -524288
+    no = sat < 1 || sat > glonassMaxSat || l1o ^. glonassL1Observation_frequency < 0 || l1o ^. glonassL1Observation_frequency > 13 || l1o ^. glonassL1Observation_carrierMinusCode == -524288
     p1 = pseudorange glonassPseudorange (l1o ^. glonassL1Observation_pseudorange) (l1eo ^. glonassL1ExtObservation_ambiguity)
     l1 = carrierPhase (glonassL1CarrierPhase (l1o ^. glonassL1Observation_frequency)) p1 (l1o ^. glonassL1Observation_carrierMinusCode)
 
@@ -242,7 +242,7 @@ toGlonassL2PackedObsContents sat l1o l1eo l2o l2eo
         , _packedObsContent_flags = obsFlags
         }
   where
-    no = sat > glonassMaxSat || l2o ^. glonassL2Observation_pseudorangeDifference == -8192 || l2o ^. glonassL2Observation_carrierMinusCode == -524288
+    no = sat < 1 || sat > glonassMaxSat || l1o ^. glonassL1Observation_frequency < 0 || l1o ^. glonassL1Observation_frequency > 13 || l2o ^. glonassL2Observation_pseudorangeDifference == -8192 || l2o ^. glonassL2Observation_carrierMinusCode == -524288
     p1 = pseudorange glonassPseudorange (l1o ^. glonassL1Observation_pseudorange) (l1eo ^. glonassL1ExtObservation_ambiguity)
     p2 = p1 + pseudorangeDifference (l2o ^. glonassL2Observation_pseudorangeDifference)
     l2 = carrierPhase (glonassL2CarrierPhase (l1o ^. glonassL1Observation_frequency)) p1 (l2o ^. glonassL2Observation_carrierMinusCode)


### PR DESCRIPTION
Add more checks around valid satellite IDs and GLONASS FCN slots.

This matches what we check in the C conversion.