### PR TITLE
EX-155: Add GLO FCN map and pass it to MSM4/6 decoders

### DIFF
--- a/c/include/rtcm3_sbp.h
+++ b/c/include/rtcm3_sbp.h
@@ -35,6 +35,12 @@
 /* MAX valid value (ms) for GPS is 604799999 and GLO is 86401999 */
 #define INVALID_TIME 0xFFFF
 
+/* GLO FCN map size is number of GLO satellites + 1 */
+#define NUM_GLO_MAP_INDICES 29
+
+#define SBP_GLO_FCN_OFFSET 8
+#define SBP_GLO_FCN_UNKNOWN 0
+
 struct rtcm3_sbp_state {
   gps_time_sec_t time_from_rover_obs;
   bool gps_time_updated;
@@ -49,6 +55,7 @@ struct rtcm3_sbp_state {
   void (*cb_base_obs_invalid)(double time_diff);
   u8 obs_buffer[OBS_BUFFER_SIZE];
   bool sent_msm_warning;
+  u8 glo_sv_id_fcn_map[NUM_GLO_MAP_INDICES];
 };
 
 void rtcm2sbp_decode_frame(const uint8_t *frame,
@@ -59,6 +66,10 @@ void rtcm2sbp_set_gps_time(gps_time_sec_t *current_time,
                            struct rtcm3_sbp_state *state);
 
 void rtcm2sbp_set_leap_second(s8 leap_seconds, struct rtcm3_sbp_state *state);
+
+void rtcm2sbp_set_glo_fcn(sbp_gnss_signal_t sid,
+                          u8 fcn,
+                          struct rtcm3_sbp_state *state);
 
 void rtcm2sbp_init(
     struct rtcm3_sbp_state *state,

--- a/c/include/rtcm3_sbp.h
+++ b/c/include/rtcm3_sbp.h
@@ -35,9 +35,6 @@
 /* MAX valid value (ms) for GPS is 604799999 and GLO is 86401999 */
 #define INVALID_TIME 0xFFFF
 
-/* GLO FCN map size is number of GLO satellites + 1 */
-#define NUM_GLO_MAP_INDICES 29
-
 #define SBP_GLO_FCN_OFFSET 8
 #define SBP_GLO_FCN_UNKNOWN 0
 
@@ -55,7 +52,8 @@ struct rtcm3_sbp_state {
   void (*cb_base_obs_invalid)(double time_diff);
   u8 obs_buffer[OBS_BUFFER_SIZE];
   bool sent_msm_warning;
-  u8 glo_sv_id_fcn_map[NUM_GLO_MAP_INDICES];
+  /* GLO FCN map, indexed by 1-based PRN */
+  u8 glo_sv_id_fcn_map[GLO_LAST_PRN + 1];
 };
 
 void rtcm2sbp_decode_frame(const uint8_t *frame,

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -15,6 +15,7 @@
 #include <math.h>
 #include <rtcm3_decode.h>
 #include <rtcm3_msm_utils.h>
+#include <stdio.h>
 #include <string.h>
 #include "rtcm3_sbp_internal.h"
 
@@ -47,6 +48,10 @@ void rtcm2sbp_init(
   state->last_msm_received.tow = 0;
 
   state->sent_msm_warning = false;
+
+  for (u8 i = 0; i < NUM_GLO_MAP_INDICES; i++) {
+    state->glo_sv_id_fcn_map[i] = MSM_GLO_FCN_UNKNOWN;
+  }
 
   memset(state->obs_buffer, 0, OBS_BUFFER_SIZE);
 }
@@ -187,7 +192,8 @@ void rtcm2sbp_decode_frame(const uint8_t *frame,
     case 1114:
     case 1124: {
       rtcm_msm_message new_rtcm_msm;
-      if (RC_OK == rtcm3_decode_msm4(&frame[byte], &new_rtcm_msm)) {
+      if (RC_OK == rtcm3_decode_msm4(
+                       &frame[byte], state->glo_sv_id_fcn_map, &new_rtcm_msm)) {
         add_msm_obs_to_buffer(&new_rtcm_msm, state);
       }
       break;
@@ -211,7 +217,8 @@ void rtcm2sbp_decode_frame(const uint8_t *frame,
     case 1116:
     case 1126: {
       rtcm_msm_message new_rtcm_msm;
-      if (RC_OK == rtcm3_decode_msm6(&frame[byte], &new_rtcm_msm)) {
+      if (RC_OK == rtcm3_decode_msm6(
+                       &frame[byte], state->glo_sv_id_fcn_map, &new_rtcm_msm)) {
         add_msm_obs_to_buffer(&new_rtcm_msm, state);
       }
       break;
@@ -781,6 +788,22 @@ void rtcm2sbp_set_gps_time(gps_time_sec_t *current_time,
 void rtcm2sbp_set_leap_second(s8 leap_seconds, struct rtcm3_sbp_state *state) {
   state->leap_seconds = leap_seconds;
   state->leap_second_known = true;
+}
+
+void rtcm2sbp_set_glo_fcn(sbp_gnss_signal_t sid,
+                          u8 sbp_fcn,
+                          struct rtcm3_sbp_state *state) {
+  /* convert FCN from SBP representation to RTCM representation */
+  if (SBP_GLO_FCN_UNKNOWN == sbp_fcn) {
+    state->glo_sv_id_fcn_map[sid.sat] = MSM_GLO_FCN_UNKNOWN;
+  } else {
+    s16 fcn = sbp_fcn - SBP_GLO_FCN_OFFSET;
+    state->glo_sv_id_fcn_map[sid.sat] = (u8)fcn + MSM_GLO_FCN_OFFSET;
+  }
+  printf("Got FCN %u for GLO sat %d, stored FCN %u\n",
+         sbp_fcn,
+         sid.sat,
+         state->glo_sv_id_fcn_map[sid.sat]);
 }
 
 void compute_gps_time(double tow_ms,

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -49,7 +49,7 @@ void rtcm2sbp_init(
 
   state->sent_msm_warning = false;
 
-  for (u8 i = 0; i < NUM_GLO_MAP_INDICES; i++) {
+  for (u8 i = 0; i < GLO_LAST_PRN + 1; i++) {
     state->glo_sv_id_fcn_map[i] = MSM_GLO_FCN_UNKNOWN;
   }
 
@@ -794,11 +794,15 @@ void rtcm2sbp_set_glo_fcn(sbp_gnss_signal_t sid,
                           u8 sbp_fcn,
                           struct rtcm3_sbp_state *state) {
   /* convert FCN from SBP representation to RTCM representation */
+  if(sid.sat < GLO_FIRST_PRN || sid.sat > GLO_LAST_PRN) {
+    /* invalid PRN */
+    return;
+  }
   if (SBP_GLO_FCN_UNKNOWN == sbp_fcn) {
     state->glo_sv_id_fcn_map[sid.sat] = MSM_GLO_FCN_UNKNOWN;
   } else {
     s16 fcn = sbp_fcn - SBP_GLO_FCN_OFFSET;
-    state->glo_sv_id_fcn_map[sid.sat] = (u8)fcn + MSM_GLO_FCN_OFFSET;
+    state->glo_sv_id_fcn_map[sid.sat] = (u8)(fcn + MSM_GLO_FCN_OFFSET);
   }
 }
 

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -800,10 +800,6 @@ void rtcm2sbp_set_glo_fcn(sbp_gnss_signal_t sid,
     s16 fcn = sbp_fcn - SBP_GLO_FCN_OFFSET;
     state->glo_sv_id_fcn_map[sid.sat] = (u8)fcn + MSM_GLO_FCN_OFFSET;
   }
-  printf("Got FCN %u for GLO sat %d, stored FCN %u\n",
-         sbp_fcn,
-         sid.sat,
-         state->glo_sv_id_fcn_map[sid.sat]);
 }
 
 void compute_gps_time(double tow_ms,

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -801,7 +801,9 @@ void rtcm2sbp_set_glo_fcn(sbp_gnss_signal_t sid,
   if (SBP_GLO_FCN_UNKNOWN == sbp_fcn) {
     state->glo_sv_id_fcn_map[sid.sat] = MSM_GLO_FCN_UNKNOWN;
   } else {
+    /* in SBP, FCN is 1..14, with the unknown value 0 already checked above */
     s8 fcn = sbp_fcn - SBP_GLO_FCN_OFFSET;
+    /* in RTCM, FCN is in 0..13 */
     state->glo_sv_id_fcn_map[sid.sat] = fcn + MSM_GLO_FCN_OFFSET;
   }
 }

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -801,8 +801,8 @@ void rtcm2sbp_set_glo_fcn(sbp_gnss_signal_t sid,
   if (SBP_GLO_FCN_UNKNOWN == sbp_fcn) {
     state->glo_sv_id_fcn_map[sid.sat] = MSM_GLO_FCN_UNKNOWN;
   } else {
-    s16 fcn = sbp_fcn - SBP_GLO_FCN_OFFSET;
-    state->glo_sv_id_fcn_map[sid.sat] = (u8)(fcn + MSM_GLO_FCN_OFFSET);
+    s8 fcn = sbp_fcn - SBP_GLO_FCN_OFFSET;
+    state->glo_sv_id_fcn_map[sid.sat] = fcn + MSM_GLO_FCN_OFFSET;
   }
 }
 


### PR DESCRIPTION
Add the GLO FCN map into state, a callback function for the `sbp_rtcm3_bridge` in buildroot to update it with, and move `librtcm` pointer to https://github.com/swift-nav/librtcm/pull/42.

# Testing

Sanity checks with stored MSM logs mainly to check that this does not crash. 

Buildroot PR using this fixed into a live MSM4 stream https://github.com/swift-nav/piksi_buildroot/pull/643
