### PR TITLE
Streamline SBP messages

### DIFF
--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -1122,8 +1122,6 @@ bool unsupported_signal(sbp_gnss_signal_t* sid) {
     case CODE_GAL_E6B:
     case CODE_GAL_E6C:
     case CODE_GAL_E6X:
-    case CODE_GAL_E7Q:
-    case CODE_GAL_E7X:
     case CODE_GAL_E5I:
     case CODE_GAL_E5Q:
     case CODE_GAL_E5X:

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -18,6 +18,7 @@
 #include <rtcm3_msm_utils.h>
 #include <stdio.h>
 #include <string.h>
+#include <libsbp/gnss.h>
 #include "rtcm3_sbp_internal.h"
 
 static void validate_base_obs_sanity(struct rtcm3_sbp_state *state,
@@ -1114,6 +1115,24 @@ static bool get_sid_from_msm(const rtcm_msm_header *header,
   }
 }
 
+bool unsupported_signal(sbp_gnss_signal_t* sid) {
+  switch(sid->code) {
+    case CODE_GPS_L5I:
+    case CODE_GPS_L5X:
+    case CODE_GPS_L5Q:
+    case CODE_GAL_E6B:
+    case CODE_GAL_E6C:
+    case CODE_GAL_E6X:
+    case CODE_GAL_E7I:
+    case CODE_GAL_E7Q:
+    case CODE_GAL_E7X:
+    case CODE_GAL_E8:
+      return true;
+    default:
+      return false;
+  }
+}
+
 void rtcm3_msm_to_sbp(const rtcm_msm_message *msg,
                       msg_obs_t *new_sbp_obs,
                       struct rtcm3_sbp_state *state) {
@@ -1130,6 +1149,10 @@ void rtcm3_msm_to_sbp(const rtcm_msm_message *msg,
         const rtcm_msm_signal_data *data = &msg->signals[cell_index];
         if (get_sid_from_msm(&msg->header, sat, sig, &sid, state) &&
             data->flags.valid_pr && data->flags.valid_cp) {
+          if(unsupported_signal(&sid)) {
+            continue;
+          }
+
           if (new_sbp_obs->header.n_obs >= MAX_OBS_PER_EPOCH) {
             send_buffer_full_error(state);
             return;

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -18,7 +18,6 @@
 #include <rtcm3_msm_utils.h>
 #include <stdio.h>
 #include <string.h>
-#include <libsbp/gnss.h>
 #include "rtcm3_sbp_internal.h"
 
 static void validate_base_obs_sanity(struct rtcm3_sbp_state *state,
@@ -1123,10 +1122,19 @@ bool unsupported_signal(sbp_gnss_signal_t* sid) {
     case CODE_GAL_E6B:
     case CODE_GAL_E6C:
     case CODE_GAL_E6X:
-    case CODE_GAL_E7I:
     case CODE_GAL_E7Q:
     case CODE_GAL_E7X:
+    case CODE_GAL_E5I:
+    case CODE_GAL_E5Q:
+    case CODE_GAL_E5X:
     case CODE_GAL_E8:
+    case CODE_QZS_L1CA:
+    case CODE_QZS_L2CM:
+    case CODE_QZS_L2CL:
+    case CODE_QZS_L2CX:
+    case CODE_QZS_L5I:
+    case CODE_QZS_L5Q:
+    case CODE_QZS_L5X:
       return true;
     default:
       return false;


### PR DESCRIPTION


Suppress the encoding into SBP of any observation types that are currently not supported on piksi.

@scarcanague @ljbade 