### PR TITLE
Add context to callbacks

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -4,6 +4,10 @@ project(gnss-converters)
 # Some compiler options used globally
 set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-strict-prototypes -Werror -std=gnu99 -fno-unwind-tables -fno-asynchronous-unwind-tables -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security -ggdb ${CMAKE_C_FLAGS}")
 
+include_directories("${PROJECT_SOURCE_DIR}/include")
+include_directories("${PROJECT_SOURCE_DIR}/libsbp/c/include")
+include_directories("${PROJECT_SOURCE_DIR}/librtcm/c/include")
+
 add_subdirectory(libsbp/c)
 add_subdirectory(librtcm/c)
 add_subdirectory(src)

--- a/c/include/rtcm3_sbp.h
+++ b/c/include/rtcm3_sbp.h
@@ -57,8 +57,9 @@ struct rtcm3_sbp_state {
   gps_time_sec_t last_glo_time;
   gps_time_sec_t last_1230_received;
   gps_time_sec_t last_msm_received;
-  void (*cb_rtcm_to_sbp)(u16 msg_id, u8 len, u8 *buff, u16 sender_id);
-  void (*cb_base_obs_invalid)(double time_diff);
+  void (*cb_rtcm_to_sbp)(u16 msg_id, u8 len, u8 *buff, u16 sender_id, void *context);
+  void (*cb_base_obs_invalid)(double time_diff, void *context);
+  void *context;
   u8 obs_buffer[OBS_BUFFER_SIZE];
   bool sent_msm_warning;
   bool sent_code_warning[UNSUPPORTED_CODE_MAX];
@@ -81,8 +82,9 @@ void rtcm2sbp_set_glo_fcn(sbp_gnss_signal_t sid,
 
 void rtcm2sbp_init(
     struct rtcm3_sbp_state *state,
-    void (*cb_rtcm_to_sbp)(u16 msg_id, u8 length, u8 *buffer, u16 sender_id),
-    void (*cb_base_obs_invalid)(double time_diff));
+    void (*cb_rtcm_to_sbp)(u16 msg_id, u8 length, u8 *buffer, u16 sender_id, void *context),
+    void (*cb_base_obs_invalid)(double time_diff, void *context),
+    void *context);
 
 #ifdef __cplusplus
 }

--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -1,9 +1,5 @@
 file(GLOB gnss_converters_HEADERS "${PROJECT_SOURCE_DIR}/include/*.h")
 
-include_directories("${PROJECT_SOURCE_DIR}/include")
-include_directories("${PROJECT_SOURCE_DIR}/libsbp/c/include")
-include_directories("${PROJECT_SOURCE_DIR}/librtcm/c/include")
-
 add_library(gnss_converters rtcm3_sbp.c rtcm3_sbp_ephemeris.c)
 target_link_libraries(gnss_converters m sbp rtcm)
 

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -29,8 +29,9 @@ static void validate_base_obs_sanity(struct rtcm3_sbp_state *state,
 
 void rtcm2sbp_init(
     struct rtcm3_sbp_state *state,
-    void (*cb_rtcm_to_sbp)(u16 msg_id, u8 length, u8 *buffer, u16 sender_id),
-    void (*cb_base_obs_invalid)(double timediff)) {
+    void (*cb_rtcm_to_sbp)(u16 msg_id, u8 length, u8 *buffer, u16 sender_id, void *context),
+    void (*cb_base_obs_invalid)(double timediff, void *context),
+    void *context) {
   state->time_from_rover_obs.wn = INVALID_TIME;
   state->time_from_rover_obs.tow = 0;
 
@@ -40,6 +41,7 @@ void rtcm2sbp_init(
   state->sender_id = 0;
   state->cb_rtcm_to_sbp = cb_rtcm_to_sbp;
   state->cb_base_obs_invalid = cb_base_obs_invalid;
+  state->context = context;
 
   state->last_gps_time.wn = INVALID_TIME;
   state->last_gps_time.tow = 0;
@@ -145,7 +147,8 @@ void rtcm2sbp_decode_frame(const uint8_t *frame,
         state->cb_rtcm_to_sbp(SBP_MSG_BASE_POS_ECEF,
                               (u8)sizeof(sbp_base_pos),
                               (u8 *)&sbp_base_pos,
-                              rtcm_2_sbp_sender_id(msg_1005.stn_id));
+                              rtcm_2_sbp_sender_id(msg_1005.stn_id),
+                              state->context);
       }
       break;
     }
@@ -157,7 +160,8 @@ void rtcm2sbp_decode_frame(const uint8_t *frame,
         state->cb_rtcm_to_sbp(SBP_MSG_BASE_POS_ECEF,
                               (u8)sizeof(sbp_base_pos),
                               (u8 *)&sbp_base_pos,
-                              rtcm_2_sbp_sender_id(msg_1006.msg_1005.stn_id));
+                              rtcm_2_sbp_sender_id(msg_1006.msg_1005.stn_id),
+                              state->context);
       }
       break;
     }
@@ -218,7 +222,8 @@ void rtcm2sbp_decode_frame(const uint8_t *frame,
         state->cb_rtcm_to_sbp(SBP_MSG_GLO_BIASES,
                               (u8)sizeof(sbp_glo_cpb),
                               (u8 *)&sbp_glo_cpb,
-                              rtcm_2_sbp_sender_id(msg_1033.stn_id));
+                              rtcm_2_sbp_sender_id(msg_1033.stn_id),
+                              state->context);
       }
       break;
     }
@@ -230,7 +235,8 @@ void rtcm2sbp_decode_frame(const uint8_t *frame,
         state->cb_rtcm_to_sbp(SBP_MSG_GLO_BIASES,
                               (u8)sizeof(sbp_glo_cpb),
                               (u8 *)&sbp_glo_cpb,
-                              rtcm_2_sbp_sender_id(msg_1230.stn_id));
+                              rtcm_2_sbp_sender_id(msg_1230.stn_id),
+                              state->context);
         state->last_1230_received = state->time_from_rover_obs;
       }
       break;
@@ -469,7 +475,7 @@ void send_observations(struct rtcm3_sbp_state *state) {
     u16 len = SBP_HDR_SIZE + obs_index * SBP_OBS_SIZE;
     assert(len <= SBP_FRAMING_MAX_PAYLOAD_SIZE);
 
-    state->cb_rtcm_to_sbp(SBP_MSG_OBS, len, obs_data, state->sender_id);
+    state->cb_rtcm_to_sbp(SBP_MSG_OBS, len, obs_data, state->sender_id, state->context);
   }
   /* clear the observation buffer, so also header.n_obs is set to zero */
   memset(state->obs_buffer, 0, OBS_BUFFER_SIZE);
@@ -967,7 +973,7 @@ static void validate_base_obs_sanity(struct rtcm3_sbp_state *state,
   /* exclude base measurements with time stamp too far in the future */
   if (timediff >= BASE_FUTURE_THRESHOLD_S &&
       state->cb_base_obs_invalid != NULL) {
-    state->cb_base_obs_invalid(timediff);
+    state->cb_base_obs_invalid(timediff, state->context);
   }
 }
 
@@ -1027,7 +1033,8 @@ void send_sbp_log_message(const uint8_t level,
   state->cb_rtcm_to_sbp(SBP_MSG_LOG,
                         sizeof(*sbp_log_msg) + length,
                         (u8 *)frame_buffer,
-                        rtcm_2_sbp_sender_id(stn_id));
+                        rtcm_2_sbp_sender_id(stn_id),
+                        state->context);
 }
 
 void send_MSM_warning(const uint8_t *frame, struct rtcm3_sbp_state *state) {

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -192,7 +192,8 @@ void rtcm2sbp_decode_frame(const uint8_t *frame,
         state->cb_rtcm_to_sbp(SBP_MSG_EPHEMERIS_GPS,
                               (u8)sizeof(sbp_gps_eph),
                               (u8 *)&sbp_gps_eph,
-                              rtcm_2_sbp_sender_id(0));
+                              rtcm_2_sbp_sender_id(0)
+                              state->context);
       }
     }
     case 1020: {
@@ -203,7 +204,8 @@ void rtcm2sbp_decode_frame(const uint8_t *frame,
         state->cb_rtcm_to_sbp(SBP_MSG_EPHEMERIS_GLO,
                               (u8)sizeof(sbp_glo_eph),
                               (u8 *)&sbp_glo_eph,
-                              rtcm_2_sbp_sender_id(0));
+                              rtcm_2_sbp_sender_id(0)
+                              state->context);
       }
     }
     case 1029: {

--- a/c/src/rtcm3_sbp.c
+++ b/c/src/rtcm3_sbp.c
@@ -192,7 +192,7 @@ void rtcm2sbp_decode_frame(const uint8_t *frame,
         state->cb_rtcm_to_sbp(SBP_MSG_EPHEMERIS_GPS,
                               (u8)sizeof(sbp_gps_eph),
                               (u8 *)&sbp_gps_eph,
-                              rtcm_2_sbp_sender_id(0)
+                              rtcm_2_sbp_sender_id(0),
                               state->context);
       }
     }
@@ -204,7 +204,7 @@ void rtcm2sbp_decode_frame(const uint8_t *frame,
         state->cb_rtcm_to_sbp(SBP_MSG_EPHEMERIS_GLO,
                               (u8)sizeof(sbp_glo_eph),
                               (u8 *)&sbp_glo_eph,
-                              rtcm_2_sbp_sender_id(0)
+                              rtcm_2_sbp_sender_id(0),
                               state->context);
       }
     }

--- a/c/tests/check_rtcm3.c
+++ b/c/tests/check_rtcm3.c
@@ -100,9 +100,10 @@ static void update_obs_time(const msg_obs_t *msg) {
   rtcm2sbp_set_gps_time(&obs_time, &state);
 }
 
-void sbp_callback_gps(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
+void sbp_callback_gps(u16 msg_id, u8 length, u8 *buffer, u16 sender_id, void *context) {
   (void)length;
   (void)sender_id;
+  (void)context;
   static uint32_t msg_count = 0;
   /* ignore log messages */
   if (msg_id == SBP_MSG_LOG) return;
@@ -117,9 +118,10 @@ void sbp_callback_gps(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   msg_count++;
 }
 
-void sbp_callback_gps_eph(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
+void sbp_callback_gps_eph(u16 msg_id, u8 length, u8 *buffer, u16 sender_id, void *context) {
   (void)length;
   (void)sender_id;
+  (void)context;
   static bool checked_eph = false;
   /* ignore log messages */
   if (msg_id == SBP_MSG_EPHEMERIS_GPS && !checked_eph) {
@@ -164,10 +166,11 @@ void sbp_callback_gps_eph(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
   return;
 }
 
-void sbp_callback_1012_first(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
+void sbp_callback_1012_first(u16 msg_id, u8 length, u8 *buffer, u16 sender_id, void *context) {
   (void)length;
   (void)buffer;
   (void)sender_id;
+  (void)context;
   if (msg_id == SBP_MSG_OBS) {
     msg_obs_t *msg = (msg_obs_t *)buffer;
     u8 num_sbp_msgs = msg->header.n_obs >> 4;
@@ -179,10 +182,12 @@ void sbp_callback_1012_first(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
 void sbp_callback_glo_day_rollover(u16 msg_id,
                                    u8 length,
                                    u8 *buffer,
-                                   u16 sender_id) {
+                                   u16 sender_id,
+                                   void *context) {
   (void)length;
   (void)buffer;
   (void)sender_id;
+  (void)context;
   if (msg_id == SBP_MSG_OBS) {
     msg_obs_t *msg = (msg_obs_t *)buffer;
     u8 num_sbp_msgs = msg->header.n_obs >> 4;
@@ -208,9 +213,10 @@ void check_biases(msg_glo_biases_t *sbp_glo_msg) {
   }
 }
 
-void sbp_callback_bias(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
+void sbp_callback_bias(u16 msg_id, u8 length, u8 *buffer, u16 sender_id, void *context) {
   (void)length;
   (void)sender_id;
+  (void)context;
   if (msg_id == SBP_MSG_GLO_BIASES) {
     msg_glo_biases_t *sbp_glo_msg = (msg_glo_biases_t *)buffer;
     check_biases(sbp_glo_msg);
@@ -222,9 +228,11 @@ void sbp_callback_bias(u16 msg_id, u8 length, u8 *buffer, u16 sender_id) {
 void sbp_callback_msm_switching(u16 msg_id,
                                 u8 length,
                                 u8 *buffer,
-                                u16 sender_id) {
+                                u16 sender_id,
+                                void *context) {
   (void)length;
   (void)sender_id;
+  (void)context;
   const u32 MAX_OBS_GAP_S = MSM_TIMEOUT_SEC + 5;
 
   if (msg_id == SBP_MSG_OBS) {
@@ -244,8 +252,10 @@ void sbp_callback_msm_switching(u16 msg_id,
 void sbp_callback_msm_no_gaps(u16 msg_id,
                               u8 length,
                               u8 *buffer,
-                              u16 sender_id) {
+                              u16 sender_id,
+                              void *context) {
   (void)sender_id;
+  (void)context;
   const u32 MAX_OBS_GAP_S = 1;
 
   if (msg_id == SBP_MSG_OBS) {
@@ -317,9 +327,9 @@ bool verify_crc(uint8_t *buffer, uint32_t buffer_length) {
 
 void test_RTCM3(
     const char *filename,
-    void (*cb_rtcm_to_sbp)(u16 msg_id, u8 length, u8 *buffer, u16 sender_id),
+    void (*cb_rtcm_to_sbp)(u16 msg_id, u8 length, u8 *buffer, u16 sender_id, void *context),
     gps_time_sec_t current_time) {
-  rtcm2sbp_init(&state, cb_rtcm_to_sbp, NULL);
+  rtcm2sbp_init(&state, cb_rtcm_to_sbp, NULL, NULL);
   rtcm2sbp_set_gps_time(&current_time, &state);
   rtcm2sbp_set_leap_second(18, &state);
 


### PR DESCRIPTION
Support context for callbacks. This will help support data to be passed to callbacks, like C++ objects and similar.

/cc @anth-cole 