### PR TITLE
Fix for [MAP-664]

### DIFF
--- a/c/src/nmea.c
+++ b/c/src/nmea.c
@@ -193,15 +193,17 @@ static void get_utc_time_string(bool time,
 
   if (time) {
     /* Time (UTC) */
+    uint16_t ns_rounded = (u16)roundf(NMEA_UTC_S_FRAC_DIVISOR * sbp_utc_time->ns * 1e-9)/NMEA_UTC_S_FRAC_DIVISOR;
+    uint16_t ns_frac = (u16)(roundf(NMEA_UTC_S_FRAC_DIVISOR * sbp_utc_time->ns * 1e-9) - NMEA_UTC_S_FRAC_DIVISOR);
     vsnprintf_wrap(
         &utc_str,
         buf_end,
         "%02u%02u%02u.%0*u,",
         sbp_utc_time->hours,
         sbp_utc_time->minutes,
-        sbp_utc_time->seconds,
+        sbp_utc_time->seconds + ns_rounded,
         NMEA_UTC_S_DECIMALS,
-        (u16)roundf(NMEA_UTC_S_FRAC_DIVISOR * sbp_utc_time->ns * 1e-9));
+        ns_frac);
   }
 
   if (date) {


### PR DESCRIPTION
When the ns field of the UTC message is 999999999 the time stamp is mislabeled to the previous second and marked as 0.1, where the ns field should roll over into the second field.

So a UTC time of 170831.99999999 was being marked as 170831.1 and not 170832.0

@nsirola can you check and see if this makes sense to you? I think we've seen this before in other cases - is there a better fix?