### PR TITLE
MAP-664: Fix the rounding of NMEA time stamp, add unit tests (#141)

### DIFF
--- a/c/src/sbp_nmea_internal.h
+++ b/c/src/sbp_nmea_internal.h
@@ -10,6 +10,10 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+#include <gnss-converters/nmea.h>
+#include <stdbool.h>
+#include <stdint.h>
+
 #define TIME_SOURCE_MASK 0x07       /* Bits 0-2 */
 #define POSITION_MODE_MASK 0x07     /* Bits 0-2 */
 #define OBSERVATION_VALID 0x1000000 /* Bits 0-7 */
@@ -18,3 +22,10 @@
 
 #define MSG_OBS_HEADER_SEQ_SHIFT 4u
 #define MSG_OBS_HEADER_SEQ_MASK ((1 << 4u) - 1)
+
+void get_utc_time_string(bool time,
+                         bool date,
+                         bool trunc_date,
+                         const msg_utc_time_t *sbp_utc_time,
+                         char *utc_str,
+                         u8 size);


### PR DESCRIPTION
* Fix the rounding of NMEA time stamp, add unit tests for [MAP-664]