### PR TITLE
Antenna known flag to restrict 1033 and 1008 messages

### DIFF
--- a/c/include/gnss-converters/rtcm3_sbp.h
+++ b/c/include/gnss-converters/rtcm3_sbp.h
@@ -77,6 +77,7 @@ struct rtcm3_sbp_state {
 struct rtcm3_out_state {
   s8 leap_seconds;
   bool leap_second_known;
+  bool ant_known;
   void (*cb_sbp_to_rtcm)(u8 *buffer, u16 length, void *context);
   u16 sender_id;
   observation_header_t sbp_header;


### PR DESCRIPTION
Only send out 1033 and 1008 messages if the antenna is known.

For VRS generated observations, we are currently translating just observations and positions and not providing any antenna or receiver descriptions. The presence of empty antenna and receiver descriptions in 1033 and 1008 over the network is not useful. Restrict their sending based on whether actual antenna data has been set.