### PR TITLE
Undefine NDEBUG so we can do release builds.

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8.7)
 project(gnss-converters)
 include(GNUInstallDirs)
 
+# If NDEBUG is defined, all asserts() will be knocked out, and
+# currently we rely on asserts() for correct behavior.
+add_compile_options(-UNDEBUG)
+
 # Some compiler options used globally
 set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-strict-prototypes -Werror -std=gnu99 -fno-unwind-tables -fno-asynchronous-unwind-tables -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security -Wfloat-conversion -ggdb ${CMAKE_C_FLAGS}")
 


### PR DESCRIPTION
Although this might slow your build down again.  Not sure what else NDEBUG controls...