### PR TITLE
Add missing break statements

### DIFF
--- a/c/include/gnss-converters/ubx_sbp.h
+++ b/c/include/gnss-converters/ubx_sbp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Swift Navigation Inc.
+ * Copyright (C) 2020 Swift Navigation Inc.
  * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must

--- a/c/src/ubx2sbp.c
+++ b/c/src/ubx2sbp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Swift Navigation Inc.
+ * Copyright (C) 2020 Swift Navigation Inc.
  * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must

--- a/c/src/ubx_sbp.c
+++ b/c/src/ubx_sbp.c
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2020 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
 #include <gnss-converters/ubx_sbp.h>
 #include <libsbp/imu.h>
 #include <libsbp/orientation.h>
@@ -940,9 +952,11 @@ void ubx_handle_frame(u8 *frame, struct ubx_sbp_state *state) {
           break;
         case UBX_MSG_ESF_MEAS:
           handle_esf_meas(state, frame);
+          break;
         default:
           break;
       }
+      break;
 
     case UBX_CLASS_HNR:
       if (msg_id == UBX_MSG_HNR_PVT) {


### PR DESCRIPTION
`ubx_handle_frame` was missing two break statements for UBX class ID ESF which was added with #316. This would cause compilation errors when compiled with `-Werror`. This PR adds those missing break statements.



