### PR TITLE
[SEN-137] Adjust M8L IMU timestamp

### DIFF
--- a/c/src/ubx_sbp.c
+++ b/c/src/ubx_sbp.c
@@ -889,6 +889,7 @@ static void handle_nav_status(struct ubx_sbp_state *state, u8 *inbuf) {
   if (gnss_fix_good && time_good) {
     state->esf_state.time_since_startup_tow_offset =
         0.001 * nav_status.i_tow - 0.001 * nav_status.msss;
+    state->esf_state.last_sync_msss = nav_status.msss;
     state->esf_state.tow_offset_set = true;
   }
 }

--- a/c/src/ubx_sbp.c
+++ b/c/src/ubx_sbp.c
@@ -710,6 +710,19 @@ static void set_sbp_imu_time(u32 sensortime_this_message,
     sensortime = sensor_tow_s;
   }
 
+  // This constant has been found empirically by comparing the M8L IMU angular
+  // rate with a properly time stamped reference.
+  const double ubx_gnss_time_error = 0.05;
+  sensortime -= ubx_gnss_time_error;
+
+  const double kSecondsInOneWeek = 7. * 24. * 3600.;
+  while (sensortime > kSecondsInOneWeek) {
+    sensortime -= kSecondsInOneWeek;
+  }
+  while (sensortime < 0) {
+    sensortime += kSecondsInOneWeek;
+  }
+
   struct sbp_imuraw_timespec timespec = convert_tow_to_imuraw_time(sensortime);
   msg->tow = timespec.tow;
   msg->tow_f = timespec.tow_f;

--- a/c/src/ubx_sbp.c
+++ b/c/src/ubx_sbp.c
@@ -712,8 +712,8 @@ static void set_sbp_imu_time(u32 sensortime_this_message,
 
   // This constant has been found empirically by comparing the M8L IMU angular
   // rate with a properly time stamped reference.
-  const double ubx_gnss_time_error = 0.05;
-  sensortime -= ubx_gnss_time_error;
+  const double ubx_imu_gnss_time_offset = 0.05;
+  sensortime -= ubx_imu_gnss_time_offset;
 
   gps_time_t gps_sensortime;
   gps_sensortime.tow = sensortime;

--- a/c/src/ubx_sbp.c
+++ b/c/src/ubx_sbp.c
@@ -715,13 +715,11 @@ static void set_sbp_imu_time(u32 sensortime_this_message,
   const double ubx_gnss_time_error = 0.05;
   sensortime -= ubx_gnss_time_error;
 
-  const double kSecondsInOneWeek = 7. * 24. * 3600.;
-  while (sensortime > kSecondsInOneWeek) {
-    sensortime -= kSecondsInOneWeek;
-  }
-  while (sensortime < 0) {
-    sensortime += kSecondsInOneWeek;
-  }
+  gps_time_t gps_sensortime;
+  gps_sensortime.tow = sensortime;
+  gps_sensortime.wn = 0;
+  unsafe_normalize_gps_time(&gps_sensortime);
+  sensortime = gps_sensortime.tow;
 
   struct sbp_imuraw_timespec timespec = convert_tow_to_imuraw_time(sensortime);
   msg->tow = timespec.tow;

--- a/c/tests/check_ubx.c
+++ b/c/tests/check_ubx.c
@@ -181,16 +181,16 @@ static void ubx_sbp_callback_esf_meas(
 }
 
 static const u16 esf_raw_crc[] = {0x598C,
-                                  0x0DC7,
-                                  0xB087,
-                                  0x6878,
-                                  0xE042,
-                                  0x1660,
-                                  0xEB46,
-                                  0x5D01,
-                                  0x794B,
-                                  0x0EAB,
-                                  0xE394};
+                                  0x4A06,
+                                  0x2DDF,
+                                  0x13BB,
+                                  0xE40B,
+                                  0x51A1,
+                                  0x2C19,
+                                  0xEAC8,
+                                  0x8D0A,
+                                  0x8560,
+                                  0x8EC4};
 static void ubx_sbp_callback_esf_raw(
     u16 msg_id, u8 length, u8 *buff, u16 sender_id, void *context) {
   (void)context;
@@ -213,8 +213,8 @@ static void ubx_sbp_callback_esf_raw(
   } else {
     ck_assert(msg_id == SBP_MSG_IMU_RAW);
     msg_imu_raw_t *msg = (msg_imu_raw_t *)buff;
-    ck_assert_int_ge(msg->tow, 325305159);
-    ck_assert_int_le(msg->tow, 325305248);
+    ck_assert_int_ge(msg->tow, 325305109);
+    ck_assert_int_le(msg->tow, 325305198);
   }
 
   /* Check that we won't receive more than 11 messages from this test file */


### PR DESCRIPTION
This PR adjusts the M8L IMU timestamp by the 50 ms offset which has been found empirically by comparing the M8L IMU angular rate  with a properly timestamped reference IMU.
