### PR TITLE
ESD-1757: introduced nmea callback function with context object as we…

### DIFF
--- a/c/include/gnss-converters/nmea.h
+++ b/c/include/gnss-converters/nmea.h
@@ -19,6 +19,10 @@
 #include <swiftnav/common.h>
 #include <swiftnav/gnss_time.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The "QI" stands for "Quality Indicator" which is the terminology used
    for this field in the NMEA specification. */
 #define NMEA_GGA_QI_INVALID 0
@@ -56,4 +60,9 @@ void send_gsv(const sbp2nmea_t *state);
 char get_nmea_status(u8 flags);
 char get_nmea_mode_indicator(u8 flags);
 u8 get_nmea_quality_indicator(u8 flags);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* SWIFTNAV_NMEA_H */

--- a/c/include/gnss-converters/sbp_nmea.h
+++ b/c/include/gnss-converters/sbp_nmea.h
@@ -79,6 +79,8 @@ typedef struct sbp2nmea_state {
   float soln_freq;
 
   void (*cb_sbp_to_nmea)();
+  void (*cb_sbp_to_nmea_ctx)(char *msg, void* ctx);
+  void* ctx;
 } sbp2nmea_t;
 
 #ifdef __cplusplus
@@ -86,6 +88,8 @@ extern "C" {
 #endif
 
 void sbp2nmea_init(sbp2nmea_t *state, void (*cb_sbp_to_nmea)(u8 msg_id[]));
+
+void sbp2nmea_ctx_init(sbp2nmea_t *state, void (*cb_sbp_to_nmea_ctx)(char* msg, void* ctx), void* ctx);
 
 void sbp2nmea(sbp2nmea_t *state,
               u8 len,

--- a/c/include/gnss-converters/sbp_nmea.h
+++ b/c/include/gnss-converters/sbp_nmea.h
@@ -78,8 +78,7 @@ typedef struct sbp2nmea_state {
 
   float soln_freq;
 
-  void (*cb_sbp_to_nmea)();
-  void (*cb_sbp_to_nmea_ctx)(char *msg, void *ctx);
+  void (*cb_sbp_to_nmea)(char *msg, void *ctx);
   void *ctx;
 } sbp2nmea_t;
 
@@ -87,11 +86,9 @@ typedef struct sbp2nmea_state {
 extern "C" {
 #endif
 
-void sbp2nmea_init(sbp2nmea_t *state, void (*cb_sbp_to_nmea)(u8 msg_id[]));
-
-void sbp2nmea_ctx_init(sbp2nmea_t *state,
-                       void (*cb_sbp_to_nmea_ctx)(char *msg, void *ctx),
-                       void *ctx);
+void sbp2nmea_init(sbp2nmea_t *state,
+                   void (*cb_sbp_to_nmea)(char *msg, void *ctx),
+                   void *ctx);
 
 void sbp2nmea(sbp2nmea_t *state,
               u8 len,

--- a/c/include/gnss-converters/sbp_nmea.h
+++ b/c/include/gnss-converters/sbp_nmea.h
@@ -79,8 +79,8 @@ typedef struct sbp2nmea_state {
   float soln_freq;
 
   void (*cb_sbp_to_nmea)();
-  void (*cb_sbp_to_nmea_ctx)(char *msg, void* ctx);
-  void* ctx;
+  void (*cb_sbp_to_nmea_ctx)(char *msg, void *ctx);
+  void *ctx;
 } sbp2nmea_t;
 
 #ifdef __cplusplus
@@ -89,7 +89,9 @@ extern "C" {
 
 void sbp2nmea_init(sbp2nmea_t *state, void (*cb_sbp_to_nmea)(u8 msg_id[]));
 
-void sbp2nmea_ctx_init(sbp2nmea_t *state, void (*cb_sbp_to_nmea_ctx)(char* msg, void* ctx), void* ctx);
+void sbp2nmea_ctx_init(sbp2nmea_t *state,
+                       void (*cb_sbp_to_nmea_ctx)(char *msg, void *ctx),
+                       void *ctx);
 
 void sbp2nmea(sbp2nmea_t *state,
               u8 len,

--- a/c/src/sbp_nmea.c
+++ b/c/src/sbp_nmea.c
@@ -284,7 +284,9 @@ void sbp2nmea_init(sbp2nmea_t *state, void (*cb_sbp_to_nmea)(u8 msg_id[])) {
   state->cb_sbp_to_nmea = cb_sbp_to_nmea;
 }
 
-void sbp2nmea_ctx_init(sbp2nmea_t *state, void (*cb_sbp_to_nmea_ctx)(char *msg, void *ctx), void* ctx) {
+void sbp2nmea_ctx_init(sbp2nmea_t *state,
+                       void (*cb_sbp_to_nmea_ctx)(char *msg, void *ctx),
+                       void *ctx) {
   memset(state, 0, sizeof(*state));
   state->cb_sbp_to_nmea_ctx = cb_sbp_to_nmea_ctx;
   state->ctx = ctx;

--- a/c/src/sbp_nmea.c
+++ b/c/src/sbp_nmea.c
@@ -10,13 +10,14 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <gnss-converters/nmea.h>
-#include <gnss-converters/sbp_nmea.h>
 #include <math.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <gnss-converters/nmea.h>
+#include <gnss-converters/sbp_nmea.h>
 #include <swiftnav/constants.h>
 #include <swiftnav/gnss_time.h>
 #include <swiftnav/memcpy_s.h>

--- a/c/src/sbp_nmea.c
+++ b/c/src/sbp_nmea.c
@@ -251,7 +251,12 @@ void sbp2nmea_obs(sbp2nmea_t *state,
 }
 
 void sbp2nmea_to_str(const sbp2nmea_t *state, char *sentence) {
-  state->cb_sbp_to_nmea(sentence);
+  if (state->cb_sbp_to_nmea) {
+    state->cb_sbp_to_nmea(sentence);
+  }
+  if (state->cb_sbp_to_nmea_ctx) {
+    state->cb_sbp_to_nmea_ctx(sentence, state->ctx);
+  }
 }
 
 void *sbp2nmea_msg_get(const sbp2nmea_t *state, sbp2nmea_sbp_id_t id) {
@@ -277,4 +282,10 @@ void sbp2nmea_soln_freq_set(sbp2nmea_t *state, float soln_freq) {
 void sbp2nmea_init(sbp2nmea_t *state, void (*cb_sbp_to_nmea)(u8 msg_id[])) {
   memset(state, 0, sizeof(*state));
   state->cb_sbp_to_nmea = cb_sbp_to_nmea;
+}
+
+void sbp2nmea_ctx_init(sbp2nmea_t *state, void (*cb_sbp_to_nmea_ctx)(char *msg, void *ctx), void* ctx) {
+  memset(state, 0, sizeof(*state));
+  state->cb_sbp_to_nmea_ctx = cb_sbp_to_nmea_ctx;
+  state->ctx = ctx;
 }

--- a/c/src/sbp_nmea.c
+++ b/c/src/sbp_nmea.c
@@ -10,20 +10,19 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include "sbp_nmea_internal.h"
-
+#include <gnss-converters/nmea.h>
+#include <gnss-converters/sbp_nmea.h>
 #include <math.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <gnss-converters/nmea.h>
-#include <gnss-converters/sbp_nmea.h>
 #include <swiftnav/constants.h>
 #include <swiftnav/gnss_time.h>
 #include <swiftnav/memcpy_s.h>
 #include <swiftnav/signal.h>
+
+#include "sbp_nmea_internal.h"
 
 struct nmea_meta_entry {
   uint16_t tow_mask;
@@ -251,12 +250,7 @@ void sbp2nmea_obs(sbp2nmea_t *state,
 }
 
 void sbp2nmea_to_str(const sbp2nmea_t *state, char *sentence) {
-  if (state->cb_sbp_to_nmea) {
-    state->cb_sbp_to_nmea(sentence);
-  }
-  if (state->cb_sbp_to_nmea_ctx) {
-    state->cb_sbp_to_nmea_ctx(sentence, state->ctx);
-  }
+  state->cb_sbp_to_nmea(sentence, state->ctx);
 }
 
 void *sbp2nmea_msg_get(const sbp2nmea_t *state, sbp2nmea_sbp_id_t id) {
@@ -279,15 +273,10 @@ void sbp2nmea_soln_freq_set(sbp2nmea_t *state, float soln_freq) {
   state->soln_freq = soln_freq;
 }
 
-void sbp2nmea_init(sbp2nmea_t *state, void (*cb_sbp_to_nmea)(u8 msg_id[])) {
+void sbp2nmea_init(sbp2nmea_t *state,
+                   void (*cb_sbp_to_nmea)(char *msg, void *ctx),
+                   void *ctx) {
   memset(state, 0, sizeof(*state));
   state->cb_sbp_to_nmea = cb_sbp_to_nmea;
-}
-
-void sbp2nmea_ctx_init(sbp2nmea_t *state,
-                       void (*cb_sbp_to_nmea_ctx)(char *msg, void *ctx),
-                       void *ctx) {
-  memset(state, 0, sizeof(*state));
-  state->cb_sbp_to_nmea_ctx = cb_sbp_to_nmea_ctx;
   state->ctx = ctx;
 }

--- a/c/tests/check_nmea.c
+++ b/c/tests/check_nmea.c
@@ -18,8 +18,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../src/sbp_nmea_internal.h"
 
+#include "../src/sbp_nmea_internal.h"
 #include "check_suites.h"
 #include "config.h"
 #include "nmea_truth.h"
@@ -45,21 +45,8 @@ static bool nmea_gsa_processed = false;
 static bool nmea_gpgst_processed = false;
 static bool nmea_gpgsv_processed = false;
 
-enum nmea_callback_index {
-  gpgga,
-  gprmc,
-  gpvtg,
-  gpgll,
-  gpzda,
-  gsa,
-  gpgst,
-  gpgsv,
-  //
-  nmea_callback_index_count
-};
-
-static int msg_count[nmea_callback_index_count];
-static bool start_count[nmea_callback_index_count];
+static int msg_count[SBP2NMEA_NMEA_CNT];
+static bool start_count[SBP2NMEA_NMEA_CNT];
 
 int32_t read_file(uint8_t *buff, uint32_t n, void *context) {
   FILE *f = (FILE *)context;
@@ -68,24 +55,26 @@ int32_t read_file(uint8_t *buff, uint32_t n, void *context) {
 
 void nmea_callback_gpgga(u8 msg[]) {
   if (strstr((char *)msg, "GGA")) {
-    if ((strstr((char *)msg, "193508.20") || start_count[gpgga]) &&
-        msg_count[gpgga] < 10) {
+    if ((strstr((char *)msg, "193508.20") || start_count[SBP2NMEA_NMEA_GGA]) &&
+        msg_count[SBP2NMEA_NMEA_GGA] < 10) {
       nmea_gpgga_processed = true;
-      start_count[gpgga] = true;
+      start_count[SBP2NMEA_NMEA_GGA] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gpgga_truth[msg_count[gpgga]++]) == 0);
+      ck_assert(strcmp((char *)msg,
+                       gpgga_truth[msg_count[SBP2NMEA_NMEA_GGA]++]) == 0);
     }
   }
 }
 
 void nmea_callback_gprmc(u8 msg[]) {
   if (strstr((char *)msg, "RMC")) {
-    if ((strstr((char *)msg, "193502.00") || start_count[gprmc]) &&
-        msg_count[gprmc] < 10) {
+    if ((strstr((char *)msg, "193502.00") || start_count[SBP2NMEA_NMEA_RMC]) &&
+        msg_count[SBP2NMEA_NMEA_RMC] < 10) {
       nmea_gprmc_processed = true;
-      start_count[gprmc] = true;
+      start_count[SBP2NMEA_NMEA_RMC] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gprmc_truth[msg_count[gprmc]++]) == 0);
+      ck_assert(strcmp((char *)msg,
+                       gprmc_truth[msg_count[SBP2NMEA_NMEA_RMC]++]) == 0);
     }
   }
 }
@@ -93,36 +82,39 @@ void nmea_callback_gprmc(u8 msg[]) {
 void nmea_callback_gpvtg(u8 msg[]) {
   if (strstr((char *)msg, "VTG")) {
     if ((strstr((char *)msg, "$GPVTG,,T,,M,0.02,N,0.04,K,A*25") ||
-         start_count[gpvtg]) &&
-        msg_count[gpvtg] < 10) {
+         start_count[SBP2NMEA_NMEA_VTG]) &&
+        msg_count[SBP2NMEA_NMEA_VTG] < 10) {
       nmea_gpvtg_processed = true;
-      start_count[gpvtg] = true;
+      start_count[SBP2NMEA_NMEA_VTG] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gpvtg_truth[msg_count[gpvtg]++]) == 0);
+      ck_assert(strcmp((char *)msg,
+                       gpvtg_truth[msg_count[SBP2NMEA_NMEA_VTG]++]) == 0);
     }
   }
 }
 
 void nmea_callback_gpgll(u8 msg[]) {
   if (strstr((char *)msg, "GLL")) {
-    if ((strstr((char *)msg, "193502.00") || start_count[gpgll]) &&
-        msg_count[gpgll] < 10) {
+    if ((strstr((char *)msg, "193502.00") || start_count[SBP2NMEA_NMEA_GLL]) &&
+        msg_count[SBP2NMEA_NMEA_GLL] < 10) {
       nmea_gpgll_processed = true;
-      start_count[gpgll] = true;
+      start_count[SBP2NMEA_NMEA_GLL] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gpgll_truth[msg_count[gpgll]++]) == 0);
+      ck_assert(strcmp((char *)msg,
+                       gpgll_truth[msg_count[SBP2NMEA_NMEA_GLL]++]) == 0);
     }
   }
 }
 
 void nmea_callback_gpzda(u8 msg[]) {
   if (strstr((char *)msg, "ZDA")) {
-    if ((strstr((char *)msg, "193502.00") || start_count[gpzda]) &&
-        msg_count[gpzda] < 10) {
+    if ((strstr((char *)msg, "193502.00") || start_count[SBP2NMEA_NMEA_ZDA]) &&
+        msg_count[SBP2NMEA_NMEA_ZDA] < 10) {
       nmea_gpzda_processed = true;
-      start_count[gpzda] = true;
+      start_count[SBP2NMEA_NMEA_ZDA] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gpzda_truth[msg_count[gpzda]++]) == 0);
+      ck_assert(strcmp((char *)msg,
+                       gpzda_truth[msg_count[SBP2NMEA_NMEA_ZDA]++]) == 0);
     }
   }
 }
@@ -145,34 +137,37 @@ void nmea_callback_gsa(u8 msg[]) {
   if (strstr((char *)msg, "GSA")) {
     if ((strstr((char *)msg,
                 "$GNGSA,A,3,414,421,426,429,435,436,,,,,,,1.8,0.9,1.6*21") ||
-         start_count[gsa]) &&
-        msg_count[gsa] < 10) {
+         start_count[SBP2NMEA_NMEA_GSA]) &&
+        msg_count[SBP2NMEA_NMEA_GSA] < 10) {
       nmea_gsa_processed = true;
-      start_count[gsa] = true;
+      start_count[SBP2NMEA_NMEA_GSA] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gsa_truth[msg_count[gsa]++]) == 0);
+      ck_assert(
+          strcmp((char *)msg, gsa_truth[msg_count[SBP2NMEA_NMEA_GSA]++]) == 0);
     }
   }
 }
 
 void nmea_callback_gpgst(u8 msg[]) {
   if (strstr((char *)msg, "GST")) {
-    if ((strstr((char *)msg, "193501.80") || start_count[gpgst]) &&
-        msg_count[gpgst] < 10) {
+    if ((strstr((char *)msg, "193501.80") || start_count[SBP2NMEA_NMEA_GST]) &&
+        msg_count[SBP2NMEA_NMEA_GST] < 10) {
       nmea_gpgst_processed = true;
-      start_count[gpgst] = true;
+      start_count[SBP2NMEA_NMEA_GST] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gst_truth[msg_count[gpgst]++]) == 0);
+      ck_assert(
+          strcmp((char *)msg, gst_truth[msg_count[SBP2NMEA_NMEA_GST]++]) == 0);
     }
   }
 }
 
 void nmea_callback_gpgsv(u8 msg[]) {
   if (strstr((char *)msg, "GSV")) {
-    if (msg_count[gpgsv] < 10) {
+    if (msg_count[SBP2NMEA_NMEA_GSV] < 10) {
       nmea_gpgsv_processed = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gsv_truth[msg_count[gpgsv]++]) == 0);
+      ck_assert(
+          strcmp((char *)msg, gsv_truth[msg_count[SBP2NMEA_NMEA_GSV]++]) == 0);
     }
   }
 }

--- a/c/tests/check_nmea.c
+++ b/c/tests/check_nmea.c
@@ -285,51 +285,17 @@ void sbp_init(sbp_state_t *sbp_state, void *ctx) {
                         &observation_callback_node);
 }
 
-void test_NMEA(const char *filename, void (*cb_sbp_to_nmea)(u8 msg[])) {
-  memset(&msg_count, 0, sizeof(msg_count));
-  memset(&start_count, 0, sizeof(start_count));
-
-  sbp2nmea_t state = {0};
-  sbp2nmea_init(&state, cb_sbp_to_nmea);
-  sbp2nmea_base_id_set(&state, 33);
-  sbp2nmea_soln_freq_set(&state, 10);
-  sbp2nmea_rate_set(&state, 1, SBP2NMEA_NMEA_GGA);
-  sbp2nmea_rate_set(&state, 10, SBP2NMEA_NMEA_RMC);
-  sbp2nmea_rate_set(&state, 10, SBP2NMEA_NMEA_VTG);
-  /*sbp2nmea_rate_set(&state, 1, SBP2NMEA_NMEA_HDT);*/
-  sbp2nmea_rate_set(&state, 10, SBP2NMEA_NMEA_GLL);
-  sbp2nmea_rate_set(&state, 10, SBP2NMEA_NMEA_ZDA);
-  sbp2nmea_rate_set(&state, 1, SBP2NMEA_NMEA_GSA);
-  sbp2nmea_rate_set(&state, 1, SBP2NMEA_NMEA_GST);
-  sbp2nmea_rate_set(&state, 10, SBP2NMEA_NMEA_GSV);
-
-  sbp_state_t sbp_state_;
-  sbp_init(&sbp_state_, &state);
-
-  FILE *fp = fopen(filename, "rb");
-  if (fp == NULL) {
-    fprintf(stderr, "Can't open input file! %s\n", filename);
-    exit(1);
-  }
-  sbp_state_set_io_context(&sbp_state_, fp);
-  while (!feof(fp)) {
-    sbp_process(&sbp_state_, &read_file);
-  }
-  fclose(fp);
-  return;
-}
-
 void cb_sbp_to_nmea_ctx_passthrough(char *msg, void *context) {
   void (*cb)(u8[]) = context;
   cb((u8 *)msg);
 }
 
-void test_NMEA_ctx(const char *filename, void (*cb_sbp_to_nmea)(u8 msg[])) {
+void test_NMEA(const char *filename, void (*cb_sbp_to_nmea)(u8 msg[])) {
   memset(&msg_count, 0, sizeof(msg_count));
   memset(&start_count, 0, sizeof(start_count));
 
   sbp2nmea_t state = {0};
-  sbp2nmea_ctx_init(&state, cb_sbp_to_nmea_ctx_passthrough, cb_sbp_to_nmea);
+  sbp2nmea_init(&state, cb_sbp_to_nmea_ctx_passthrough, cb_sbp_to_nmea);
   sbp2nmea_base_id_set(&state, 33);
   sbp2nmea_soln_freq_set(&state, 10);
   sbp2nmea_rate_set(&state, 1, SBP2NMEA_NMEA_GGA);
@@ -361,34 +327,19 @@ void test_NMEA_ctx(const char *filename, void (*cb_sbp_to_nmea)(u8 msg[])) {
 void nmea_setup_basic(void) { return; }
 
 START_TEST(test_nmea_gpgga) {
-  nmea_gpgga_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgga);
-  ck_assert(nmea_gpgga_processed);
-
-  nmea_gpgga_processed = false;
-  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgga);
   ck_assert(nmea_gpgga_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gprmc) {
-  nmea_gprmc_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gprmc);
-  ck_assert(nmea_gprmc_processed);
-
-  nmea_gprmc_processed = false;
-  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gprmc);
   ck_assert(nmea_gprmc_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gpvtg) {
-  nmea_gpvtg_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpvtg);
-  ck_assert(nmea_gpvtg_processed);
-
-  nmea_gpvtg_processed = false;
-  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpvtg);
   ck_assert(nmea_gpvtg_processed);
 }
 END_TEST
@@ -401,56 +352,31 @@ END_TEST
 END_TEST */
 
 START_TEST(test_nmea_gpgll) {
-  nmea_gpgll_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgll);
-  ck_assert(nmea_gpgll_processed);
-
-  nmea_gpgll_processed = false;
-  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgll);
   ck_assert(nmea_gpgll_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gpzda) {
-  nmea_gpzda_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpzda);
-  ck_assert(nmea_gpzda_processed);
-
-  nmea_gpzda_processed = false;
-  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpzda);
   ck_assert(nmea_gpzda_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gsa) {
-  nmea_gsa_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gsa);
-  ck_assert(nmea_gsa_processed);
-
-  nmea_gsa_processed = false;
-  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gsa);
   ck_assert(nmea_gsa_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gpgst) {
-  nmea_gpgst_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgst);
-  ck_assert(nmea_gpgst_processed);
-
-  nmea_gpgst_processed = false;
-  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgst);
   ck_assert(nmea_gpgst_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gpgsv) {
-  nmea_gpgsv_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/azel-sbp.sbp", nmea_callback_gpgsv);
-  ck_assert(nmea_gpgsv_processed);
-
-  nmea_gpgsv_processed = false;
-  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/azel-sbp.sbp", nmea_callback_gpgsv);
   ck_assert(nmea_gpgsv_processed);
 }
 END_TEST

--- a/c/tests/check_nmea.c
+++ b/c/tests/check_nmea.c
@@ -53,8 +53,8 @@ int32_t read_file(uint8_t *buff, uint32_t n, void *context) {
   return (int32_t)(fread(buff, 1, n, f));
 }
 
-void nmea_callback_gpgga(char msg[], void* ctx) {
-  (void) ctx;
+void nmea_callback_gpgga(char msg[], void *ctx) {
+  (void)ctx;
   if (strstr((char *)msg, "GGA")) {
     if ((strstr((char *)msg, "193508.20") || start_count[SBP2NMEA_NMEA_GGA]) &&
         msg_count[SBP2NMEA_NMEA_GGA] < 10) {
@@ -67,8 +67,8 @@ void nmea_callback_gpgga(char msg[], void* ctx) {
   }
 }
 
-void nmea_callback_gprmc(char msg[], void* ctx) {
-  (void) ctx;
+void nmea_callback_gprmc(char msg[], void *ctx) {
+  (void)ctx;
   if (strstr((char *)msg, "RMC")) {
     if ((strstr((char *)msg, "193502.00") || start_count[SBP2NMEA_NMEA_RMC]) &&
         msg_count[SBP2NMEA_NMEA_RMC] < 10) {
@@ -81,8 +81,8 @@ void nmea_callback_gprmc(char msg[], void* ctx) {
   }
 }
 
-void nmea_callback_gpvtg(char msg[], void* ctx) {
-  (void) ctx;
+void nmea_callback_gpvtg(char msg[], void *ctx) {
+  (void)ctx;
   if (strstr((char *)msg, "VTG")) {
     if ((strstr((char *)msg, "$GPVTG,,T,,M,0.02,N,0.04,K,A*25") ||
          start_count[SBP2NMEA_NMEA_VTG]) &&
@@ -96,8 +96,8 @@ void nmea_callback_gpvtg(char msg[], void* ctx) {
   }
 }
 
-void nmea_callback_gpgll(char msg[], void* ctx) {
-  (void) ctx;
+void nmea_callback_gpgll(char msg[], void *ctx) {
+  (void)ctx;
   if (strstr((char *)msg, "GLL")) {
     if ((strstr((char *)msg, "193502.00") || start_count[SBP2NMEA_NMEA_GLL]) &&
         msg_count[SBP2NMEA_NMEA_GLL] < 10) {
@@ -110,8 +110,8 @@ void nmea_callback_gpgll(char msg[], void* ctx) {
   }
 }
 
-void nmea_callback_gpzda(char msg[], void* ctx) {
-  (void) ctx;
+void nmea_callback_gpzda(char msg[], void *ctx) {
+  (void)ctx;
   if (strstr((char *)msg, "ZDA")) {
     if ((strstr((char *)msg, "193502.00") || start_count[SBP2NMEA_NMEA_ZDA]) &&
         msg_count[SBP2NMEA_NMEA_ZDA] < 10) {
@@ -138,8 +138,8 @@ void nmea_callback_gpzda(char msg[], void* ctx) {
   }
 } */
 
-void nmea_callback_gsa(char msg[], void* ctx) {
-  (void) ctx;
+void nmea_callback_gsa(char msg[], void *ctx) {
+  (void)ctx;
   if (strstr((char *)msg, "GSA")) {
     if ((strstr((char *)msg,
                 "$GNGSA,A,3,414,421,426,429,435,436,,,,,,,1.8,0.9,1.6*21") ||
@@ -154,8 +154,8 @@ void nmea_callback_gsa(char msg[], void* ctx) {
   }
 }
 
-void nmea_callback_gpgst(char msg[], void* ctx) {
-  (void) ctx;
+void nmea_callback_gpgst(char msg[], void *ctx) {
+  (void)ctx;
   if (strstr((char *)msg, "GST")) {
     if ((strstr((char *)msg, "193501.80") || start_count[SBP2NMEA_NMEA_GST]) &&
         msg_count[SBP2NMEA_NMEA_GST] < 10) {
@@ -168,8 +168,8 @@ void nmea_callback_gpgst(char msg[], void* ctx) {
   }
 }
 
-void nmea_callback_gpgsv(char msg[], void* ctx) {
-  (void) ctx;
+void nmea_callback_gpgsv(char msg[], void *ctx) {
+  (void)ctx;
   if (strstr((char *)msg, "GSV")) {
     if (msg_count[SBP2NMEA_NMEA_GSV] < 10) {
       nmea_gpgsv_processed = true;
@@ -293,7 +293,8 @@ void sbp_init(sbp_state_t *sbp_state, void *ctx) {
                         &observation_callback_node);
 }
 
-void test_NMEA(const char *filename, void (*cb_sbp_to_nmea)(char msg[], void* ctx)) {
+void test_NMEA(const char *filename,
+               void (*cb_sbp_to_nmea)(char msg[], void *ctx)) {
   memset(&msg_count, 0, sizeof(msg_count));
   memset(&start_count, 0, sizeof(start_count));
 

--- a/c/tests/check_nmea.c
+++ b/c/tests/check_nmea.c
@@ -53,7 +53,8 @@ int32_t read_file(uint8_t *buff, uint32_t n, void *context) {
   return (int32_t)(fread(buff, 1, n, f));
 }
 
-void nmea_callback_gpgga(u8 msg[]) {
+void nmea_callback_gpgga(char msg[], void* ctx) {
+  (void) ctx;
   if (strstr((char *)msg, "GGA")) {
     if ((strstr((char *)msg, "193508.20") || start_count[SBP2NMEA_NMEA_GGA]) &&
         msg_count[SBP2NMEA_NMEA_GGA] < 10) {
@@ -66,7 +67,8 @@ void nmea_callback_gpgga(u8 msg[]) {
   }
 }
 
-void nmea_callback_gprmc(u8 msg[]) {
+void nmea_callback_gprmc(char msg[], void* ctx) {
+  (void) ctx;
   if (strstr((char *)msg, "RMC")) {
     if ((strstr((char *)msg, "193502.00") || start_count[SBP2NMEA_NMEA_RMC]) &&
         msg_count[SBP2NMEA_NMEA_RMC] < 10) {
@@ -79,7 +81,8 @@ void nmea_callback_gprmc(u8 msg[]) {
   }
 }
 
-void nmea_callback_gpvtg(u8 msg[]) {
+void nmea_callback_gpvtg(char msg[], void* ctx) {
+  (void) ctx;
   if (strstr((char *)msg, "VTG")) {
     if ((strstr((char *)msg, "$GPVTG,,T,,M,0.02,N,0.04,K,A*25") ||
          start_count[SBP2NMEA_NMEA_VTG]) &&
@@ -93,7 +96,8 @@ void nmea_callback_gpvtg(u8 msg[]) {
   }
 }
 
-void nmea_callback_gpgll(u8 msg[]) {
+void nmea_callback_gpgll(char msg[], void* ctx) {
+  (void) ctx;
   if (strstr((char *)msg, "GLL")) {
     if ((strstr((char *)msg, "193502.00") || start_count[SBP2NMEA_NMEA_GLL]) &&
         msg_count[SBP2NMEA_NMEA_GLL] < 10) {
@@ -106,7 +110,8 @@ void nmea_callback_gpgll(u8 msg[]) {
   }
 }
 
-void nmea_callback_gpzda(u8 msg[]) {
+void nmea_callback_gpzda(char msg[], void* ctx) {
+  (void) ctx;
   if (strstr((char *)msg, "ZDA")) {
     if ((strstr((char *)msg, "193502.00") || start_count[SBP2NMEA_NMEA_ZDA]) &&
         msg_count[SBP2NMEA_NMEA_ZDA] < 10) {
@@ -133,7 +138,8 @@ void nmea_callback_gpzda(u8 msg[]) {
   }
 } */
 
-void nmea_callback_gsa(u8 msg[]) {
+void nmea_callback_gsa(char msg[], void* ctx) {
+  (void) ctx;
   if (strstr((char *)msg, "GSA")) {
     if ((strstr((char *)msg,
                 "$GNGSA,A,3,414,421,426,429,435,436,,,,,,,1.8,0.9,1.6*21") ||
@@ -148,7 +154,8 @@ void nmea_callback_gsa(u8 msg[]) {
   }
 }
 
-void nmea_callback_gpgst(u8 msg[]) {
+void nmea_callback_gpgst(char msg[], void* ctx) {
+  (void) ctx;
   if (strstr((char *)msg, "GST")) {
     if ((strstr((char *)msg, "193501.80") || start_count[SBP2NMEA_NMEA_GST]) &&
         msg_count[SBP2NMEA_NMEA_GST] < 10) {
@@ -161,7 +168,8 @@ void nmea_callback_gpgst(u8 msg[]) {
   }
 }
 
-void nmea_callback_gpgsv(u8 msg[]) {
+void nmea_callback_gpgsv(char msg[], void* ctx) {
+  (void) ctx;
   if (strstr((char *)msg, "GSV")) {
     if (msg_count[SBP2NMEA_NMEA_GSV] < 10) {
       nmea_gpgsv_processed = true;
@@ -285,17 +293,12 @@ void sbp_init(sbp_state_t *sbp_state, void *ctx) {
                         &observation_callback_node);
 }
 
-void cb_sbp_to_nmea_ctx_passthrough(char *msg, void *context) {
-  void (*cb)(u8[]) = context;
-  cb((u8 *)msg);
-}
-
-void test_NMEA(const char *filename, void (*cb_sbp_to_nmea)(u8 msg[])) {
+void test_NMEA(const char *filename, void (*cb_sbp_to_nmea)(char msg[], void* ctx)) {
   memset(&msg_count, 0, sizeof(msg_count));
   memset(&start_count, 0, sizeof(start_count));
 
   sbp2nmea_t state = {0};
-  sbp2nmea_init(&state, cb_sbp_to_nmea_ctx_passthrough, cb_sbp_to_nmea);
+  sbp2nmea_init(&state, cb_sbp_to_nmea, NULL);
   sbp2nmea_base_id_set(&state, 33);
   sbp2nmea_soln_freq_set(&state, 10);
   sbp2nmea_rate_set(&state, 1, SBP2NMEA_NMEA_GGA);

--- a/c/tests/check_nmea.c
+++ b/c/tests/check_nmea.c
@@ -45,6 +45,22 @@ static bool nmea_gsa_processed = false;
 static bool nmea_gpgst_processed = false;
 static bool nmea_gpgsv_processed = false;
 
+enum nmea_callback_index {
+  gpgga,
+  gprmc,
+  gpvtg,
+  gpgll,
+  gpzda,
+  gsa,
+  gpgst,
+  gpgsv,
+  //
+  nmea_callback_index_count
+};
+
+static int msg_count[nmea_callback_index_count];
+static bool start_count[nmea_callback_index_count];
+
 int32_t read_file(uint8_t *buff, uint32_t n, void *context) {
   FILE *f = (FILE *)context;
   return (int32_t)(fread(buff, 1, n, f));
@@ -52,67 +68,61 @@ int32_t read_file(uint8_t *buff, uint32_t n, void *context) {
 
 void nmea_callback_gpgga(u8 msg[]) {
   if (strstr((char *)msg, "GGA")) {
-    static int msg_count = 0;
-    static bool start_count = false;
-    if ((strstr((char *)msg, "193508.20") || start_count) && msg_count < 10) {
+    if ((strstr((char *)msg, "193508.20") || start_count[gpgga]) &&
+        msg_count[gpgga] < 10) {
       nmea_gpgga_processed = true;
-      start_count = true;
+      start_count[gpgga] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gpgga_truth[msg_count++]) == 0);
+      ck_assert(strcmp((char *)msg, gpgga_truth[msg_count[gpgga]++]) == 0);
     }
   }
 }
 
 void nmea_callback_gprmc(u8 msg[]) {
   if (strstr((char *)msg, "RMC")) {
-    static int msg_count = 0;
-    static bool start_count = false;
-    if ((strstr((char *)msg, "193502.00") || start_count) && msg_count < 10) {
+    if ((strstr((char *)msg, "193502.00") || start_count[gprmc]) &&
+        msg_count[gprmc] < 10) {
       nmea_gprmc_processed = true;
-      start_count = true;
+      start_count[gprmc] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gprmc_truth[msg_count++]) == 0);
+      ck_assert(strcmp((char *)msg, gprmc_truth[msg_count[gprmc]++]) == 0);
     }
   }
 }
 
 void nmea_callback_gpvtg(u8 msg[]) {
   if (strstr((char *)msg, "VTG")) {
-    static int msg_count = 0;
-    static bool start_count = false;
     if ((strstr((char *)msg, "$GPVTG,,T,,M,0.02,N,0.04,K,A*25") ||
-         start_count) &&
-        msg_count < 10) {
+         start_count[gpvtg]) &&
+        msg_count[gpvtg] < 10) {
       nmea_gpvtg_processed = true;
-      start_count = true;
+      start_count[gpvtg] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gpvtg_truth[msg_count++]) == 0);
+      ck_assert(strcmp((char *)msg, gpvtg_truth[msg_count[gpvtg]++]) == 0);
     }
   }
 }
 
 void nmea_callback_gpgll(u8 msg[]) {
   if (strstr((char *)msg, "GLL")) {
-    static int msg_count = 0;
-    static bool start_count = false;
-    if ((strstr((char *)msg, "193502.00") || start_count) && msg_count < 10) {
+    if ((strstr((char *)msg, "193502.00") || start_count[gpgll]) &&
+        msg_count[gpgll] < 10) {
       nmea_gpgll_processed = true;
-      start_count = true;
+      start_count[gpgll] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gpgll_truth[msg_count++]) == 0);
+      ck_assert(strcmp((char *)msg, gpgll_truth[msg_count[gpgll]++]) == 0);
     }
   }
 }
 
 void nmea_callback_gpzda(u8 msg[]) {
   if (strstr((char *)msg, "ZDA")) {
-    static int msg_count = 0;
-    static bool start_count = false;
-    if ((strstr((char *)msg, "193502.00") || start_count) && msg_count < 10) {
+    if ((strstr((char *)msg, "193502.00") || start_count[gpzda]) &&
+        msg_count[gpzda] < 10) {
       nmea_gpzda_processed = true;
-      start_count = true;
+      start_count[gpzda] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gpzda_truth[msg_count++]) == 0);
+      ck_assert(strcmp((char *)msg, gpzda_truth[msg_count[gpzda]++]) == 0);
     }
   }
 }
@@ -133,40 +143,36 @@ void nmea_callback_gpzda(u8 msg[]) {
 
 void nmea_callback_gsa(u8 msg[]) {
   if (strstr((char *)msg, "GSA")) {
-    static int msg_count = 0;
-    static bool start_count = false;
     if ((strstr((char *)msg,
                 "$GNGSA,A,3,414,421,426,429,435,436,,,,,,,1.8,0.9,1.6*21") ||
-         start_count) &&
-        msg_count < 10) {
+         start_count[gsa]) &&
+        msg_count[gsa] < 10) {
       nmea_gsa_processed = true;
-      start_count = true;
+      start_count[gsa] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gsa_truth[msg_count++]) == 0);
+      ck_assert(strcmp((char *)msg, gsa_truth[msg_count[gsa]++]) == 0);
     }
   }
 }
 
 void nmea_callback_gpgst(u8 msg[]) {
   if (strstr((char *)msg, "GST")) {
-    static int msg_count = 0;
-    static bool start_count = false;
-    if ((strstr((char *)msg, "193501.80") || start_count) && msg_count < 10) {
+    if ((strstr((char *)msg, "193501.80") || start_count[gpgst]) &&
+        msg_count[gpgst] < 10) {
       nmea_gpgst_processed = true;
-      start_count = true;
+      start_count[gpgst] = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gst_truth[msg_count++]) == 0);
+      ck_assert(strcmp((char *)msg, gst_truth[msg_count[gpgst]++]) == 0);
     }
   }
 }
 
 void nmea_callback_gpgsv(u8 msg[]) {
   if (strstr((char *)msg, "GSV")) {
-    static int msg_count = 0;
-    if (msg_count < 10) {
+    if (msg_count[gpgsv] < 10) {
       nmea_gpgsv_processed = true;
       msg[strcspn((char *)msg, "\r\n")] = '\0';
-      ck_assert(strcmp((char *)msg, gsv_truth[msg_count++]) == 0);
+      ck_assert(strcmp((char *)msg, gsv_truth[msg_count[gpgsv]++]) == 0);
     }
   }
 }
@@ -285,8 +291,50 @@ void sbp_init(sbp_state_t *sbp_state, void *ctx) {
 }
 
 void test_NMEA(const char *filename, void (*cb_sbp_to_nmea)(u8 msg[])) {
+  memset(&msg_count, 0, sizeof(msg_count));
+  memset(&start_count, 0, sizeof(start_count));
+
   sbp2nmea_t state = {0};
   sbp2nmea_init(&state, cb_sbp_to_nmea);
+  sbp2nmea_base_id_set(&state, 33);
+  sbp2nmea_soln_freq_set(&state, 10);
+  sbp2nmea_rate_set(&state, 1, SBP2NMEA_NMEA_GGA);
+  sbp2nmea_rate_set(&state, 10, SBP2NMEA_NMEA_RMC);
+  sbp2nmea_rate_set(&state, 10, SBP2NMEA_NMEA_VTG);
+  /*sbp2nmea_rate_set(&state, 1, SBP2NMEA_NMEA_HDT);*/
+  sbp2nmea_rate_set(&state, 10, SBP2NMEA_NMEA_GLL);
+  sbp2nmea_rate_set(&state, 10, SBP2NMEA_NMEA_ZDA);
+  sbp2nmea_rate_set(&state, 1, SBP2NMEA_NMEA_GSA);
+  sbp2nmea_rate_set(&state, 1, SBP2NMEA_NMEA_GST);
+  sbp2nmea_rate_set(&state, 10, SBP2NMEA_NMEA_GSV);
+
+  sbp_state_t sbp_state_;
+  sbp_init(&sbp_state_, &state);
+
+  FILE *fp = fopen(filename, "rb");
+  if (fp == NULL) {
+    fprintf(stderr, "Can't open input file! %s\n", filename);
+    exit(1);
+  }
+  sbp_state_set_io_context(&sbp_state_, fp);
+  while (!feof(fp)) {
+    sbp_process(&sbp_state_, &read_file);
+  }
+  fclose(fp);
+  return;
+}
+
+void cb_sbp_to_nmea_ctx_passthrough(char *msg, void *context) {
+  void (*cb)(u8[]) = context;
+  cb((u8 *)msg);
+}
+
+void test_NMEA_ctx(const char *filename, void (*cb_sbp_to_nmea)(u8 msg[])) {
+  memset(&msg_count, 0, sizeof(msg_count));
+  memset(&start_count, 0, sizeof(start_count));
+
+  sbp2nmea_t state = {0};
+  sbp2nmea_ctx_init(&state, cb_sbp_to_nmea_ctx_passthrough, cb_sbp_to_nmea);
   sbp2nmea_base_id_set(&state, 33);
   sbp2nmea_soln_freq_set(&state, 10);
   sbp2nmea_rate_set(&state, 1, SBP2NMEA_NMEA_GGA);
@@ -318,19 +366,34 @@ void test_NMEA(const char *filename, void (*cb_sbp_to_nmea)(u8 msg[])) {
 void nmea_setup_basic(void) { return; }
 
 START_TEST(test_nmea_gpgga) {
+  nmea_gpgga_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgga);
+  ck_assert(nmea_gpgga_processed);
+
+  nmea_gpgga_processed = false;
+  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgga);
   ck_assert(nmea_gpgga_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gprmc) {
+  nmea_gprmc_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gprmc);
+  ck_assert(nmea_gprmc_processed);
+
+  nmea_gprmc_processed = false;
+  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gprmc);
   ck_assert(nmea_gprmc_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gpvtg) {
+  nmea_gpvtg_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpvtg);
+  ck_assert(nmea_gpvtg_processed);
+
+  nmea_gpvtg_processed = false;
+  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpvtg);
   ck_assert(nmea_gpvtg_processed);
 }
 END_TEST
@@ -343,31 +406,56 @@ END_TEST
 END_TEST */
 
 START_TEST(test_nmea_gpgll) {
+  nmea_gpgll_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgll);
+  ck_assert(nmea_gpgll_processed);
+
+  nmea_gpgll_processed = false;
+  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgll);
   ck_assert(nmea_gpgll_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gpzda) {
+  nmea_gpzda_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpzda);
+  ck_assert(nmea_gpzda_processed);
+
+  nmea_gpzda_processed = false;
+  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpzda);
   ck_assert(nmea_gpzda_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gsa) {
+  nmea_gsa_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gsa);
+  ck_assert(nmea_gsa_processed);
+
+  nmea_gsa_processed = false;
+  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gsa);
   ck_assert(nmea_gsa_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gpgst) {
+  nmea_gpgst_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgst);
+  ck_assert(nmea_gpgst_processed);
+
+  nmea_gpgst_processed = false;
+  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/nmea.sbp", nmea_callback_gpgst);
   ck_assert(nmea_gpgst_processed);
 }
 END_TEST
 
 START_TEST(test_nmea_gpgsv) {
+  nmea_gpgsv_processed = false;
   test_NMEA(RELATIVE_PATH_PREFIX "/data/azel-sbp.sbp", nmea_callback_gpgsv);
+  ck_assert(nmea_gpgsv_processed);
+
+  nmea_gpgsv_processed = false;
+  test_NMEA_ctx(RELATIVE_PATH_PREFIX "/data/azel-sbp.sbp", nmea_callback_gpgsv);
   ck_assert(nmea_gpgsv_processed);
 }
 END_TEST


### PR DESCRIPTION
PR introduces two elements, 1 bug fix and 1 new feature.

The bug fix is quite simple, when trying to call any of the function within `nmea.h` from a C++ code base, it fails to link because the C++ reads that header files as if it follows the C++ style function name mangling, which isn't the case as the source file is written in C.

The feature addition was again quite simple, originally NMEA had a callback function which wasn't taking any arguments. This is a bit limiting because that would mean that whatever is performed within the callback needs to call static variables, which with regards to our swiftlets work isn't good enough as we might have multiple sbp2nmea states.

**NOTE**: if there anyone else that I need to add to this PR, please let me know, I just added in what github has recommended to me