### PR TITLE
Bump to latest open source publish of libswiftnav

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image is created by https://github.com/swift-nav/docker-recipes
-FROM 571934480752.dkr.ecr.us-west-2.amazonaws.com/swift-build-modern-rust:2023-04-25
+FROM 571934480752.dkr.ecr.us-west-2.amazonaws.com/swift-build:2021-06-07
 
 # Add anything that's specific to this repo's build environment here.
 RUN sudo mkdir -p /usr/share/man/man1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Base image is created by https://github.com/swift-nav/docker-recipes
-FROM 571934480752.dkr.ecr.us-west-2.amazonaws.com/swift-build-rust:2022-05-25
+FROM 571934480752.dkr.ecr.us-west-2.amazonaws.com/swift-build-modern-rust:2023-04-25
 
 # Add anything that's specific to this repo's build environment here.
-RUN sudo mkdir -p /usr/share/man/man1
-RUN sudo apt-get update && sudo apt-get install -y sqlite3 afl++
+RUN sudo mkdir -p /usr/share/man/man1 \
+    && sudo apt-get update \
+    && sudo apt-get install --no-install-recommends -y sqlite3 afl++

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image is created by https://github.com/swift-nav/docker-recipes
-FROM 571934480752.dkr.ecr.us-west-2.amazonaws.com/swift-build:2021-06-07
+FROM 571934480752.dkr.ecr.us-west-2.amazonaws.com/swift-build-modern-rust:2023-04-25
 
 # Add anything that's specific to this repo's build environment here.
 RUN sudo mkdir -p /usr/share/man/man1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image is created by https://github.com/swift-nav/docker-recipes
-FROM 571934480752.dkr.ecr.us-west-2.amazonaws.com/swift-build:2021-06-07
+FROM 571934480752.dkr.ecr.us-west-2.amazonaws.com/swift-build-rust:2022-05-25
 
 # Add anything that's specific to this repo's build environment here.
 RUN sudo mkdir -p /usr/share/man/man1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,21 +30,6 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '3'))
     }
 
-    // Overwrite in stages that need clang
-    environment {
-        // Default compiler. Override in each stage as needed.
-        CC='gcc-6'
-        CXX='g++-6'
-        COMPILER='gcc-6'
-
-        // Default parallelism for make
-        MAKEJ='4'
-
-        // Since ~/.ccache is mounted from a shared NFS disk, make sure the temp
-        // dir is local to the container.
-        CCACHE_TEMPDIR='/tmp/ccache_tmp'
-    }
-
     stages {
         stage('Build') {
             parallel {

--- a/c/afl/make_afl_testcases.c
+++ b/c/afl/make_afl_testcases.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 
 #include "make_afl_testcases.h"
+
 #include <assert.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/c/afl/make_rtcm_testcases.c
+++ b/c/afl/make_rtcm_testcases.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <swiftnav/bits.h>
 #include <swiftnav/edc.h>
+
 #include "make_afl_testcases.h"
 
 #define RTCM3_PREAMBLE 0xD3

--- a/c/afl/make_ubx_testcases.c
+++ b/c/afl/make_ubx_testcases.c
@@ -1,5 +1,6 @@
 #include <ubx/decode.h>
 #include <ubx/encode.h>
+
 #include "make_afl_testcases.h"
 
 static u8 output_buf[4096];

--- a/c/gnss_converters/include/gnss-converters/ixcom_sbp.h
+++ b/c/gnss_converters/include/gnss-converters/ixcom_sbp.h
@@ -13,12 +13,10 @@
 #ifndef GNSS_CONVERTERS_IXCOM_SBP_INTERFACE_H
 #define GNSS_CONVERTERS_IXCOM_SBP_INTERFACE_H
 
+#include <ixcom/messages.h>
+#include <libsbp/sbp.h>
 #include <stddef.h>
 #include <unistd.h>
-
-#include <libsbp/sbp.h>
-
-#include <ixcom/messages.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/c/gnss_converters/include/gnss-converters/ubx_sbp.h
+++ b/c/gnss_converters/include/gnss-converters/ubx_sbp.h
@@ -13,15 +13,15 @@
 #ifndef GNSS_CONVERTERS_UBX_SBP_INTERFACE_H
 #define GNSS_CONVERTERS_UBX_SBP_INTERFACE_H
 
+#include <gnss-converters/eph_sat_data.h>
 #include <libsbp/sbp.h>
 #include <libsbp/v4/gnss.h>
 #include <libsbp/v4/navigation.h>
 #include <libsbp/v4/observation.h>
 #include <libsbp/v4/orientation.h>
+#include <swiftnav/bytestream.h>
 #include <unistd.h>
 
-#include <gnss-converters/eph_sat_data.h>
-#include <swiftnav/bytestream.h>
 #include "swiftnav/gnss_time.h"
 #include "swiftnav/signal.h"
 

--- a/c/gnss_converters/src/ixcom_sbp.c
+++ b/c/gnss_converters/src/ixcom_sbp.c
@@ -1,14 +1,11 @@
 #include <assert.h>
-#include <math.h>
-#include <stddef.h>
-#include <string.h>
-
+#include <gnss-converters/ixcom_sbp.h>
 #include <ixcom/decode.h>
 #include <libsbp/v4/imu.h>
 #include <libsbp/v4/vehicle.h>
-
-#include <gnss-converters/ixcom_sbp.h>
-
+#include <math.h>
+#include <stddef.h>
+#include <string.h>
 #include <swiftnav/constants.h>
 
 #define ODO_TIMESOURCE_GPS 0x1

--- a/c/gnss_converters/src/nmea.c
+++ b/c/gnss_converters/src/nmea.c
@@ -10,15 +10,12 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include "sbp_nmea_internal.h"
-
 #include <assert.h>
+#include <gnss-converters/nmea.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <gnss-converters/nmea.h>
 #include <swiftnav/array_tools.h>
 #include <swiftnav/common.h>
 #include <swiftnav/constants.h>
@@ -26,6 +23,8 @@
 #include <swiftnav/gnss_time.h>
 #include <swiftnav/pvt_result.h>
 #include <swiftnav/signal.h>
+
+#include "sbp_nmea_internal.h"
 
 /** \addtogroup io
  * \{ */

--- a/c/gnss_converters/src/options.c
+++ b/c/gnss_converters/src/options.c
@@ -10,7 +10,6 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 #include <assert.h>
-
 #include <gnss-converters/options.h>
 #include <rtcm3/constants.h>
 #include <rtcm3/msm_utils.h>

--- a/c/gnss_converters/src/rtcm3_sbp.c
+++ b/c/gnss_converters/src/rtcm3_sbp.c
@@ -134,8 +134,8 @@ void rtcm2sbp_decode_payload(const uint8_t *payload,
                              uint32_t payload_length,
                              struct rtcm3_sbp_state *state) {
   (void)payload_length;
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, payload, payload_length * 8);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, payload, payload_length * 8);
 
   if (payload_length < 2) {
     return;
@@ -1349,14 +1349,14 @@ void send_sbp_log_message(const uint8_t level,
       rtcm_stn_to_sbp_sender_id(stn_id), SbpMsgLog, &msg, state->context);
 }
 
-void send_MSM_warning(const swiftnav_bitstream_t *bitstream,
+void send_MSM_warning(const swiftnav_in_bitstream_t *bitstream,
                       struct rtcm3_sbp_state *state) {
   if (!state->sent_msm_warning) {
     /* Only send 1 warning */
     state->sent_msm_warning = true;
     /* Get the stn ID as well */
     uint32_t stn_id = 0;
-    if (swiftnav_bitstream_getbitu(bitstream, &stn_id, 12, 24)) {
+    if (swiftnav_in_bitstream_getbitu(bitstream, &stn_id, 12, 24)) {
       uint8_t msg[39] = "MSM1-3 Messages currently not supported";
       send_sbp_log_message(
           RTCM_MSM_LOGGING_LEVEL, msg, sizeof(msg), stn_id, state);

--- a/c/gnss_converters/src/rtcm3_sbp_ephemeris.c
+++ b/c/gnss_converters/src/rtcm3_sbp_ephemeris.c
@@ -69,10 +69,7 @@ values, N = 0-6: use 2^(1+N/2) (round to one
 decimal place i.e. 2.8, 5.7 and 11.3) , N=
 7-15:use 2^(N-2), 8192 specifies use at own
 risk) */
-  if (ura >= ARRAY_SIZE(g_bds_ura_table)) {
-    return -1;
-  }
-  float m = g_bds_ura_table[ura];
+  float m = decode_bds_ura_index(ura);
   if (float_equal(INVALID_URA_VALUE, m)) {
     return 8192.0f;
   }

--- a/c/gnss_converters/src/rtcm3_sbp_ephemeris.c
+++ b/c/gnss_converters/src/rtcm3_sbp_ephemeris.c
@@ -15,6 +15,7 @@
 #include <swiftnav/constants.h>
 #include <swiftnav/ephemeris.h>
 #include <swiftnav/float_equality.h>
+
 #include "ephemeris/sbas.h"
 #include "rtcm3_sbp_internal.h"
 #include "rtcm3_utils.h"

--- a/c/gnss_converters/src/rtcm3_sbp_internal.h
+++ b/c/gnss_converters/src/rtcm3_sbp_internal.h
@@ -19,6 +19,7 @@
 #include <swiftnav/constants.h>
 #include <swiftnav/gnss_time.h>
 #include <swiftnav/signal.h>
+
 #include "common.h"
 #include "gnss-converters/rtcm3_sbp.h"
 

--- a/c/gnss_converters/src/rtcm3_sbp_internal.h
+++ b/c/gnss_converters/src/rtcm3_sbp_internal.h
@@ -152,7 +152,7 @@ void send_sbp_log_message(uint8_t level,
                           uint16_t stn_id,
                           const struct rtcm3_sbp_state *state);
 
-void send_MSM_warning(const swiftnav_bitstream_t *bitstream,
+void send_MSM_warning(const swiftnav_in_bitstream_t *bitstream,
                       struct rtcm3_sbp_state *state);
 
 void send_buffer_full_error(const struct rtcm3_sbp_state *state);

--- a/c/gnss_converters/src/rtcm3_sbp_ssr.c
+++ b/c/gnss_converters/src/rtcm3_sbp_ssr.c
@@ -15,6 +15,7 @@
 #include <math.h>
 #include <rtcm3/msm_utils.h>
 #include <string.h>
+
 #include "rtcm3_sbp_internal.h"
 
 #define SSR_MESSAGE_LENGTH 256

--- a/c/gnss_converters/src/rtcm3_utils.c
+++ b/c/gnss_converters/src/rtcm3_utils.c
@@ -455,7 +455,7 @@ bool msm_signal_frequency(const rtcm_msm_header *header,
         return false;
       }
     case CODE_BDS2_B1:
-      *p_freq = BDS2_B11_HZ;
+      *p_freq = BDS2_B1I_HZ;
       return true;
     case CODE_BDS2_B2:
       *p_freq = BDS2_B2_HZ;

--- a/c/gnss_converters/src/rtcm3_utils.c
+++ b/c/gnss_converters/src/rtcm3_utils.c
@@ -24,11 +24,10 @@
 #include "rtcm3_utils.h"
 
 #include <assert.h>
-#include <stdbool.h>
-#include <stdint.h>
-
 #include <rtcm3/constants.h>
 #include <rtcm3/msm_utils.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <swiftnav/constants.h>
 #include <swiftnav/logging.h>
 #include <swiftnav/signal.h>

--- a/c/gnss_converters/src/rtcm3_utils.h
+++ b/c/gnss_converters/src/rtcm3_utils.h
@@ -13,10 +13,9 @@
 #ifndef GNSS_CONVERTERS_RTCM3_UTILS_H
 #define GNSS_CONVERTERS_RTCM3_UTILS_H
 
+#include <rtcm3/messages.h>
 #include <stdbool.h>
 #include <stdint.h>
-
-#include <rtcm3/messages.h>
 #include <swiftnav/signal.h>
 
 #define GPS_TOE_RESOLUTION 16

--- a/c/gnss_converters/src/sbp_nmea.c
+++ b/c/gnss_converters/src/sbp_nmea.c
@@ -10,13 +10,12 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+#include <gnss-converters/nmea.h>
+#include <gnss-converters/sbp_nmea.h>
 #include <math.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <gnss-converters/nmea.h>
-#include <gnss-converters/sbp_nmea.h>
 #include <swiftnav/constants.h>
 #include <swiftnav/gnss_time.h>
 #include <swiftnav/memcpy_s.h>

--- a/c/gnss_converters/test/check_options.c
+++ b/c/gnss_converters/test/check_options.c
@@ -11,9 +11,8 @@
  */
 
 #include <check.h>
-#include <math.h>
-
 #include <gnss-converters/options.h>
+#include <math.h>
 #include <rtcm3/messages.h>
 #include <rtcm3/msm_utils.h>
 #include <rtcm3_utils.h>

--- a/c/gnss_converters_extra/src/sbp_conv.c
+++ b/c/gnss_converters_extra/src/sbp_conv.c
@@ -10,16 +10,14 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <gnss-converters-extra/sbp_conv.h>
-
 #include <assert.h>
+#include <gnss-converters-extra/sbp_conv.h>
+#include <gnss-converters-extra/sbp_rtcm3.h>
 #include <libsbp/legacy/logging.h>
 #include <libsbp/sbp.h>
 #include <swiftnav/fifo_byte.h>
 #include <swiftnav/gnss_time.h>
 #include <time.h>
-
-#include <gnss-converters-extra/sbp_rtcm3.h>
 
 struct sbp_conv_s {
   struct rtcm3_out_state state;
@@ -114,7 +112,9 @@ size_t sbp_conv(sbp_conv_t conv,
       sbp2rtcm_sbp_log_cb(sender, (u8)rlen, rbuf, &conv->state);
       break;
     }
-    default: { break; }
+    default: {
+      break;
+    }
   }
   return fifo_read(&conv->fifo, wbuf, (u32)wlen);
 }

--- a/c/gnss_converters_extra/src/sbp_rtcm3.c
+++ b/c/gnss_converters_extra/src/sbp_rtcm3.c
@@ -10,13 +10,12 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <assert.h>
-#include <math.h>
-#include <stdlib.h>
-#include <string.h>
+#include "gnss-converters-extra/sbp_rtcm3.h"
 
+#include <assert.h>
 #include <libsbp/legacy/gnss.h>
 #include <libsbp/legacy/logging.h>
+#include <math.h>
 #include <rtcm3/bits.h>
 #include <rtcm3/decode.h>
 #include <rtcm3/encode.h>
@@ -24,6 +23,8 @@
 #include <rtcm3/eph_encode.h>
 #include <rtcm3/logging.h>
 #include <rtcm3/ssr_decode.h>
+#include <stdlib.h>
+#include <string.h>
 #include <swiftnav/edc.h>
 #include <swiftnav/ephemeris.h>
 #include <swiftnav/fifo_byte.h>
@@ -34,7 +35,6 @@
 #include <swiftnav/signal.h>
 #include <swiftnav/swift_strnlen.h>
 
-#include "gnss-converters-extra/sbp_rtcm3.h"
 #include "gnss-converters/utils.h"
 #include "rtcm3_utils.h"
 #include "sbp_rtcm3_internal.h"

--- a/c/gnss_converters_extra/src/sbp_rtcm3_internal.h
+++ b/c/gnss_converters_extra/src/sbp_rtcm3_internal.h
@@ -18,6 +18,7 @@
 #include <swiftnav/constants.h>
 #include <swiftnav/gnss_time.h>
 #include <swiftnav/signal.h>
+
 #include "common.h"
 #include "gnss-converters-extra/sbp_rtcm3.h"
 

--- a/c/gnss_converters_extra/test/check_utils.c
+++ b/c/gnss_converters_extra/test/check_utils.c
@@ -16,14 +16,13 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../../gnss_converters_extra/src/sbp_rtcm3_internal.h"
+#include "../src/rtcm3_sbp_internal.h"
+#include "../src/rtcm3_utils.h"
 #include "common.h"
 #include "gnss-converters-extra/sbp_rtcm3.h"
 #include "gnss-converters/rtcm3_sbp.h"
 #include "libsbp/legacy/logging.h"
-
-#include "../../gnss_converters_extra/src/sbp_rtcm3_internal.h"
-#include "../src/rtcm3_sbp_internal.h"
-#include "../src/rtcm3_utils.h"
 
 #define FREQ_TOL 1e-3
 

--- a/c/ixcom2sbp/src/ixcom2sbp.c
+++ b/c/ixcom2sbp/src/ixcom2sbp.c
@@ -11,11 +11,10 @@
  */
 
 #include <getopt.h>
+#include <gnss-converters/ixcom_sbp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <gnss-converters/ixcom_sbp.h>
 
 sbp_state_t sbp_state;
 

--- a/c/ixcom2sbp/test/check_ixcom2sbp.c
+++ b/c/ixcom2sbp/test/check_ixcom2sbp.c
@@ -11,21 +11,17 @@
  */
 
 #include <check.h>
+#include <gnss-converters/ixcom_sbp.h>
+#include <ixcom/decode.h>
+#include <ixcom/messages.h>
+#include <libsbp/edc.h>
+#include <libsbp/v4/imu.h>
+#include <libsbp/v4/logging.h>
+#include <libsbp/v4/vehicle.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <libsbp/edc.h>
-#include <libsbp/v4/imu.h>
-#include <libsbp/v4/vehicle.h>
-
-#include <gnss-converters/ixcom_sbp.h>
-
-#include <libsbp/v4/logging.h>
-
-#include <ixcom/decode.h>
-#include <ixcom/messages.h>
 
 #include "config.h"
 

--- a/c/libixcom/include/ixcom/XCOMdat.h
+++ b/c/libixcom/include/ixcom/XCOMdat.h
@@ -8,7 +8,6 @@
 #define XCOMDAT_H_
 
 #include <stdint.h>
-
 #include <swiftnav/macros.h>
 
 /*

--- a/c/libixcom/include/ixcom/messages.h
+++ b/c/libixcom/include/ixcom/messages.h
@@ -13,11 +13,10 @@
 #ifndef SWIFTNAV_IXCOM_MESSAGES_H
 #define SWIFTNAV_IXCOM_MESSAGES_H
 
+#include <ixcom/XCOMdat.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-
-#include <ixcom/XCOMdat.h>
 
 size_t ixcom_set_bytes(const uint8_t *src, uint8_t *dest, size_t num_bytes);
 

--- a/c/libixcom/src/decode.c
+++ b/c/libixcom/src/decode.c
@@ -10,9 +10,8 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <swiftnav/bits.h>
-
 #include <ixcom/decode.h>
+#include <swiftnav/bits.h>
 
 /* iXCOM is a little-endian protocol. This library assumes the host system is
  * also little-endian.

--- a/c/libixcom/src/encode.c
+++ b/c/libixcom/src/encode.c
@@ -10,9 +10,8 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <swiftnav/bits.h>
-
 #include <ixcom/encode.h>
+#include <swiftnav/bits.h>
 
 /* Serialize the iXCOM Header
  *

--- a/c/libixcom/src/messages.c
+++ b/c/libixcom/src/messages.c
@@ -10,9 +10,8 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <string.h>
-
 #include <ixcom/messages.h>
+#include <string.h>
 
 /* iXCOM protocol is little-endian */
 

--- a/c/libixcom/test/check_ixcom.c
+++ b/c/libixcom/test/check_ixcom.c
@@ -12,14 +12,13 @@
 
 #include <assert.h>
 #include <check.h>
+#include <ixcom/decode.h>
+#include <ixcom/encode.h>
+#include <ixcom/messages.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <ixcom/decode.h>
-#include <ixcom/encode.h>
-#include <ixcom/messages.h>
 
 #include "check_suites.h"
 

--- a/c/libixcom/test/check_main.c
+++ b/c/libixcom/test/check_main.c
@@ -1,6 +1,5 @@
-#include <stdlib.h>
-
 #include <check.h>
+#include <stdlib.h>
 
 #include "check_suites.h"
 

--- a/c/librtcm/include/rtcm3/bits.h
+++ b/c/librtcm/include/rtcm3/bits.h
@@ -14,6 +14,7 @@
 #define SWIFTNAV_RTCM3_BITS_H
 
 #include <swiftnav/bitstream.h>
+
 #include "rtcm3/messages.h"
 #ifdef __cplusplus
 extern "C" {

--- a/c/librtcm/include/rtcm3/bits.h
+++ b/c/librtcm/include/rtcm3/bits.h
@@ -32,7 +32,7 @@ void rtcm_setbitsl(uint8_t *buff, uint32_t pos, uint32_t len, int64_t data);
 int32_t rtcm_get_sign_magnitude_bit(const uint8_t *buff,
                                     uint32_t pos,
                                     uint8_t len);
-rtcm3_rc rtcm_get_sign_magnitude_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm_get_sign_magnitude_bitstream(swiftnav_in_bitstream_t *buff,
                                            uint8_t len,
                                            int32_t *out);
 void rtcm_set_sign_magnitude_bit(uint8_t *buff,

--- a/c/librtcm/include/rtcm3/decode.h
+++ b/c/librtcm/include/rtcm3/decode.h
@@ -22,41 +22,41 @@ extern "C" {
 
 #include <rtcm3/messages.h>
 
-rtcm3_rc rtcm3_decode_1001_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1001_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1001);
-rtcm3_rc rtcm3_decode_1002_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1002_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1002);
-rtcm3_rc rtcm3_decode_1003_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1003_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1003);
-rtcm3_rc rtcm3_decode_1004_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1004_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1004);
-rtcm3_rc rtcm3_decode_1005_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1005_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1005 *msg_1005);
-rtcm3_rc rtcm3_decode_1006_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1006_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1006 *msg_1006);
-rtcm3_rc rtcm3_decode_1007_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1007_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1007 *msg_1007);
-rtcm3_rc rtcm3_decode_1008_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1008_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1008 *msg_1008);
-rtcm3_rc rtcm3_decode_1010_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1010_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1010);
-rtcm3_rc rtcm3_decode_1012_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1012_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1012);
-rtcm3_rc rtcm3_decode_1029_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1029_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1029 *msg_1029);
-rtcm3_rc rtcm3_decode_1033_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1033_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1033 *msg_1033);
-rtcm3_rc rtcm3_decode_1230_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1230_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1230 *msg_1230);
-rtcm3_rc rtcm3_decode_msm4_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_msm4_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msm_message *msg);
-rtcm3_rc rtcm3_decode_msm5_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_msm5_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msm_message *msg);
-rtcm3_rc rtcm3_decode_msm6_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_msm6_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msm_message *msg);
-rtcm3_rc rtcm3_decode_msm7_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_msm7_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msm_message *msg);
-rtcm3_rc rtcm3_decode_4062_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_4062_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_swift_proprietary *msg);
 rtcm3_rc rtcm3_decode_4075(const uint8_t buff[], rtcm_msg_ndf *msg);
 
@@ -67,127 +67,127 @@ double rtcm3_decode_lock_time(uint8_t lock);
 
 static inline rtcm3_rc rtcm3_decode_1001(const uint8_t buff[],
                                          rtcm_obs_message *msg_1001) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1001_bitstream(&bitstream, msg_1001);
 }
 
 static inline rtcm3_rc rtcm3_decode_1002(const uint8_t buff[],
                                          rtcm_obs_message *msg_1002) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1002_bitstream(&bitstream, msg_1002);
 }
 
 static inline rtcm3_rc rtcm3_decode_1003(const uint8_t buff[],
                                          rtcm_obs_message *msg_1003) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1003_bitstream(&bitstream, msg_1003);
 }
 
 static inline rtcm3_rc rtcm3_decode_1004(const uint8_t buff[],
                                          rtcm_obs_message *msg_1004) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1004_bitstream(&bitstream, msg_1004);
 }
 
 static inline rtcm3_rc rtcm3_decode_1005(const uint8_t buff[],
                                          rtcm_msg_1005 *msg_1005) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1005_bitstream(&bitstream, msg_1005);
 }
 
 static inline rtcm3_rc rtcm3_decode_1006(const uint8_t buff[],
                                          rtcm_msg_1006 *msg_1006) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1006_bitstream(&bitstream, msg_1006);
 }
 
 static inline rtcm3_rc rtcm3_decode_1007(const uint8_t buff[],
                                          rtcm_msg_1007 *msg_1007) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1007_bitstream(&bitstream, msg_1007);
 }
 
 static inline rtcm3_rc rtcm3_decode_1008(const uint8_t buff[],
                                          rtcm_msg_1008 *msg_1008) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1008_bitstream(&bitstream, msg_1008);
 }
 
 static inline rtcm3_rc rtcm3_decode_1010(const uint8_t buff[],
                                          rtcm_obs_message *msg_1010) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1010_bitstream(&bitstream, msg_1010);
 }
 
 static inline rtcm3_rc rtcm3_decode_1012(const uint8_t buff[],
                                          rtcm_obs_message *msg_1012) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1012_bitstream(&bitstream, msg_1012);
 }
 
 static inline rtcm3_rc rtcm3_decode_1029(const uint8_t buff[],
                                          rtcm_msg_1029 *msg_1029) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1029_bitstream(&bitstream, msg_1029);
 }
 
 static inline rtcm3_rc rtcm3_decode_1033(const uint8_t buff[],
                                          rtcm_msg_1033 *msg_1033) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1033_bitstream(&bitstream, msg_1033);
 }
 
 static inline rtcm3_rc rtcm3_decode_1230(const uint8_t buff[],
                                          rtcm_msg_1230 *msg_1230) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_1230_bitstream(&bitstream, msg_1230);
 }
 
 static inline rtcm3_rc rtcm3_decode_msm4(const uint8_t buff[],
                                          rtcm_msm_message *msg) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_msm4_bitstream(&bitstream, msg);
 }
 
 static inline rtcm3_rc rtcm3_decode_msm5(const uint8_t buff[],
                                          rtcm_msm_message *msg) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_msm5_bitstream(&bitstream, msg);
 }
 
 static inline rtcm3_rc rtcm3_decode_msm6(const uint8_t buff[],
                                          rtcm_msm_message *msg) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_msm6_bitstream(&bitstream, msg);
 }
 
 static inline rtcm3_rc rtcm3_decode_msm7(const uint8_t buff[],
                                          rtcm_msm_message *msg) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_msm7_bitstream(&bitstream, msg);
 }
 
 static inline rtcm3_rc rtcm3_decode_4062(const uint8_t buff[],
                                          rtcm_msg_swift_proprietary *msg) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_4062_bitstream(&bitstream, msg);
 }
 

--- a/c/librtcm/include/rtcm3/eph_decode.h
+++ b/c/librtcm/include/rtcm3/eph_decode.h
@@ -21,58 +21,58 @@
 extern "C" {
 #endif
 
-rtcm3_rc rtcm3_decode_gps_eph_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_gps_eph_bitstream(swiftnav_in_bitstream_t *buff,
                                         rtcm_msg_eph *msg_eph);
-rtcm3_rc rtcm3_decode_glo_eph_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_glo_eph_bitstream(swiftnav_in_bitstream_t *buff,
                                         rtcm_msg_eph *msg_eph);
-rtcm3_rc rtcm3_decode_gal_eph_inav_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_gal_eph_inav_bitstream(swiftnav_in_bitstream_t *buff,
                                              rtcm_msg_eph *msg_eph);
-rtcm3_rc rtcm3_decode_gal_eph_fnav_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_gal_eph_fnav_bitstream(swiftnav_in_bitstream_t *buff,
                                              rtcm_msg_eph *msg_eph);
-rtcm3_rc rtcm3_decode_bds_eph_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_bds_eph_bitstream(swiftnav_in_bitstream_t *buff,
                                         rtcm_msg_eph *msg_eph);
-rtcm3_rc rtcm3_decode_qzss_eph_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_qzss_eph_bitstream(swiftnav_in_bitstream_t *buff,
                                          rtcm_msg_eph *msg_eph);
 
 static inline rtcm3_rc rtcm3_decode_gps_eph(const uint8_t buff[],
                                             rtcm_msg_eph *msg_eph) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_gps_eph_bitstream(&bitstream, msg_eph);
 }
 
 static inline rtcm3_rc rtcm3_decode_glo_eph(const uint8_t buff[],
                                             rtcm_msg_eph *msg_eph) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_glo_eph_bitstream(&bitstream, msg_eph);
 }
 
 static inline rtcm3_rc rtcm3_decode_gal_eph_inav(const uint8_t buff[],
                                                  rtcm_msg_eph *msg_eph) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_gal_eph_inav_bitstream(&bitstream, msg_eph);
 }
 
 static inline rtcm3_rc rtcm3_decode_gal_eph_fnav(const uint8_t buff[],
                                                  rtcm_msg_eph *msg_eph) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_gal_eph_fnav_bitstream(&bitstream, msg_eph);
 }
 
 static inline rtcm3_rc rtcm3_decode_bds_eph(const uint8_t buff[],
                                             rtcm_msg_eph *msg_eph) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_bds_eph_bitstream(&bitstream, msg_eph);
 }
 
 static inline rtcm3_rc rtcm3_decode_qzss_eph(const uint8_t buff[],
                                              rtcm_msg_eph *msg_eph) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_qzss_eph_bitstream(&bitstream, msg_eph);
 }
 

--- a/c/librtcm/include/rtcm3/messages.h
+++ b/c/librtcm/include/rtcm3/messages.h
@@ -15,6 +15,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+
 #include "rtcm3/constants.h"
 
 #ifdef __cplusplus

--- a/c/librtcm/include/rtcm3/ssr_decode.h
+++ b/c/librtcm/include/rtcm3/ssr_decode.h
@@ -16,49 +16,49 @@
 #include <rtcm3/messages.h>
 #include <swiftnav/bitstream.h>
 
-rtcm3_rc rtcm3_decode_orbit_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_orbit_bitstream(swiftnav_in_bitstream_t *buff,
                                       rtcm_msg_orbit *msg_orbit);
-rtcm3_rc rtcm3_decode_clock_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_clock_bitstream(swiftnav_in_bitstream_t *buff,
                                       rtcm_msg_clock *msg_clock);
 rtcm3_rc rtcm3_decode_orbit_clock_bitstream(
-    swiftnav_bitstream_t *buff, rtcm_msg_orbit_clock *msg_orbit_clock);
-rtcm3_rc rtcm3_decode_code_bias_bitstream(swiftnav_bitstream_t *buff,
+    swiftnav_in_bitstream_t *buff, rtcm_msg_orbit_clock *msg_orbit_clock);
+rtcm3_rc rtcm3_decode_code_bias_bitstream(swiftnav_in_bitstream_t *buff,
                                           rtcm_msg_code_bias *msg_code_bias);
-rtcm3_rc rtcm3_decode_phase_bias_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_phase_bias_bitstream(swiftnav_in_bitstream_t *buff,
                                            rtcm_msg_phase_bias *msg_phase_bias);
 
 static inline rtcm3_rc rtcm3_decode_orbit(const uint8_t buff[],
                                           rtcm_msg_orbit *msg_orbit) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_orbit_bitstream(&bitstream, msg_orbit);
 }
 
 static inline rtcm3_rc rtcm3_decode_clock(const uint8_t buff[],
                                           rtcm_msg_clock *msg_clock) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_clock_bitstream(&bitstream, msg_clock);
 }
 
 static inline rtcm3_rc rtcm3_decode_orbit_clock(
     const uint8_t buff[], rtcm_msg_orbit_clock *msg_orbit_clock) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_orbit_clock_bitstream(&bitstream, msg_orbit_clock);
 }
 
 static inline rtcm3_rc rtcm3_decode_code_bias(
     const uint8_t buff[], rtcm_msg_code_bias *msg_code_bias) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_code_bias_bitstream(&bitstream, msg_code_bias);
 }
 
 static inline rtcm3_rc rtcm3_decode_phase_bias(
     const uint8_t buff[], rtcm_msg_phase_bias *msg_phase_bias) {
-  swiftnav_bitstream_t bitstream;
-  swiftnav_bitstream_init(&bitstream, buff, UINT32_MAX);
+  swiftnav_in_bitstream_t bitstream;
+  swiftnav_in_bitstream_init(&bitstream, buff, UINT32_MAX);
   return rtcm3_decode_phase_bias_bitstream(&bitstream, msg_phase_bias);
 }
 

--- a/c/librtcm/src/bits.c
+++ b/c/librtcm/src/bits.c
@@ -198,7 +198,7 @@ void rtcm_set_sign_magnitude_bit(uint8_t *buff,
   rtcm_setbitu(buff, pos + 1, len - 1, ((data < 0) ? -data : data));
 }
 
-rtcm3_rc rtcm_get_sign_magnitude_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm_get_sign_magnitude_bitstream(swiftnav_in_bitstream_t *buff,
                                            uint8_t len,
                                            s32 *out) {
   uint32_t sign;

--- a/c/librtcm/src/bits.c
+++ b/c/librtcm/src/bits.c
@@ -11,9 +11,9 @@
  */
 
 #include <rtcm3/bits.h>
-#include "rtcm3/messages.h"
 
 #include "decode_helpers.h"
+#include "rtcm3/messages.h"
 
 /** Get bit field from buffer as an unsigned integer.
  * Unpacks `len` bits at bit position `pos` from the start of the buffer.

--- a/c/librtcm/src/decode.c
+++ b/c/librtcm/src/decode.c
@@ -134,7 +134,7 @@ static uint32_t from_msm_lock_ind_ext(uint16_t lock) {
   return 67108864;
 }
 
-static rtcm3_rc decode_basic_gps_l1_freq_data(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_basic_gps_l1_freq_data(swiftnav_in_bitstream_t *buff,
                                               rtcm_freq_data *freq_data,
                                               uint32_t *pr,
                                               int32_t *phr_pr_diff) {
@@ -148,7 +148,7 @@ static rtcm3_rc decode_basic_gps_l1_freq_data(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_basic_glo_l1_freq_data(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_basic_glo_l1_freq_data(swiftnav_in_bitstream_t *buff,
                                               rtcm_freq_data *freq_data,
                                               uint32_t *pr,
                                               int32_t *phr_pr_diff,
@@ -163,7 +163,7 @@ static rtcm3_rc decode_basic_glo_l1_freq_data(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_basic_l2_freq_data(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_basic_l2_freq_data(swiftnav_in_bitstream_t *buff,
                                           rtcm_freq_data *freq_data,
                                           int32_t *pr,
                                           int32_t *phr_pr_diff) {
@@ -177,7 +177,7 @@ static rtcm3_rc decode_basic_l2_freq_data(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc rtcm3_read_header(swiftnav_bitstream_t *buff,
+static rtcm3_rc rtcm3_read_header(swiftnav_in_bitstream_t *buff,
                                   rtcm_obs_header *header) {
   BITSTREAM_DECODE_U16(buff, header->msg_num, 12);
   BITSTREAM_DECODE_U16(buff, header->stn_id, 12);
@@ -189,7 +189,7 @@ static rtcm3_rc rtcm3_read_header(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc rtcm3_read_glo_header(swiftnav_bitstream_t *buff,
+static rtcm3_rc rtcm3_read_glo_header(swiftnav_in_bitstream_t *buff,
                                       rtcm_obs_header *header) {
   BITSTREAM_DECODE_U16(buff, header->msg_num, 12);
   BITSTREAM_DECODE_U16(buff, header->stn_id, 12);
@@ -210,13 +210,13 @@ static uint32_t normalize_bds2_tow(const uint32_t tow_ms) {
   return tow_ms;
 }
 
-static rtcm3_rc rtcm3_read_msm_header(swiftnav_bitstream_t *buff,
+static rtcm3_rc rtcm3_read_msm_header(swiftnav_in_bitstream_t *buff,
                                       const rtcm_constellation_t cons,
                                       rtcm_msm_header *header) {
   BITSTREAM_DECODE_U16(buff, header->stn_id, 12);
   if (RTCM_CONSTELLATION_GLO == cons) {
     /* skip the day of week, it is handled in gnss_converters */
-    swiftnav_bitstream_remove(buff, 3);
+    swiftnav_in_bitstream_remove(buff, 3);
     /* for GLONASS, the epoch time is the time of day in ms */
     BITSTREAM_DECODE_U32(buff, header->tow_ms, 27);
   } else if (RTCM_CONSTELLATION_BDS == cons) {
@@ -298,7 +298,7 @@ static uint8_t construct_L2_phase(rtcm_freq_data *l2_freq_data,
   return 0;
 }
 
-static rtcm3_rc get_cnr(rtcm_freq_data *freq_data, swiftnav_bitstream_t *buff) {
+static rtcm3_rc get_cnr(rtcm_freq_data *freq_data, swiftnav_in_bitstream_t *buff) {
   uint32_t cnr;
   BITSTREAM_DECODE_U32(buff, cnr, 8);
   if (cnr == 0) {
@@ -318,7 +318,7 @@ static rtcm3_rc get_cnr(rtcm_freq_data *freq_data, swiftnav_bitstream_t *buff) {
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : TOW sanity check fail
  */
-rtcm3_rc rtcm3_decode_1001_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1001_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1001) {
   assert(msg_1001);
   rtcm3_rc ret = rtcm3_read_header(buff, &msg_1001->header);
@@ -367,7 +367,7 @@ rtcm3_rc rtcm3_decode_1001_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : TOW sanity check fail
  */
-rtcm3_rc rtcm3_decode_1002_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1002_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1002) {
   assert(msg_1002);
   rtcm3_rc ret = rtcm3_read_header(buff, &msg_1002->header);
@@ -422,7 +422,7 @@ rtcm3_rc rtcm3_decode_1002_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : TOW sanity check fail
  */
-rtcm3_rc rtcm3_decode_1003_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1003_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1003) {
   assert(msg_1003);
   rtcm3_rc ret = rtcm3_read_header(buff, &msg_1003->header);
@@ -485,7 +485,7 @@ rtcm3_rc rtcm3_decode_1003_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : TOW sanity check fail
  */
-rtcm3_rc rtcm3_decode_1004_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1004_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1004) {
   assert(msg_1004);
   rtcm3_rc ret = rtcm3_read_header(buff, &msg_1004->header);
@@ -551,7 +551,7 @@ rtcm3_rc rtcm3_decode_1004_bitstream(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc rtcm3_decode_1005_base(swiftnav_bitstream_t *buff,
+static rtcm3_rc rtcm3_decode_1005_base(swiftnav_in_bitstream_t *buff,
                                        rtcm_msg_1005 *msg_1005) {
   BITSTREAM_DECODE_U16(buff, msg_1005->stn_id, 12);
   BITSTREAM_DECODE_U8(buff, msg_1005->ITRF, 6);
@@ -563,7 +563,7 @@ static rtcm3_rc rtcm3_decode_1005_base(swiftnav_bitstream_t *buff,
   BITSTREAM_DECODE_S64(buff, tmp, 38);
   msg_1005->arp_x = (double)(tmp) / 10000.0;
   BITSTREAM_DECODE_U8(buff, msg_1005->osc_ind, 1);
-  swiftnav_bitstream_remove(buff, 1);
+  swiftnav_in_bitstream_remove(buff, 1);
   BITSTREAM_DECODE_S64(buff, tmp, 38);
   msg_1005->arp_y = (double)(tmp) / 10000.0;
   BITSTREAM_DECODE_U8(buff, msg_1005->quart_cycle_ind, 2);
@@ -580,7 +580,7 @@ static rtcm3_rc rtcm3_decode_1005_base(swiftnav_bitstream_t *buff,
  * \return  - RC_OK : Success
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  */
-rtcm3_rc rtcm3_decode_1005_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1005_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1005 *msg_1005) {
   assert(msg_1005);
   uint32_t msg_num;
@@ -601,7 +601,7 @@ rtcm3_rc rtcm3_decode_1005_bitstream(swiftnav_bitstream_t *buff,
  * \return  - RC_OK : Success
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  */
-rtcm3_rc rtcm3_decode_1006_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1006_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1006 *msg_1006) {
   assert(msg_1006);
   uint32_t msg_num;
@@ -618,7 +618,7 @@ rtcm3_rc rtcm3_decode_1006_bitstream(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_string(swiftnav_bitstream_t *buff, u8 *len, char *str) {
+static rtcm3_rc decode_string(swiftnav_in_bitstream_t *buff, u8 *len, char *str) {
   BITSTREAM_DECODE_U8(buff, *len, 8);
   if (*len > RTCM_MAX_STRING_LEN) {
     return RC_INVALID_MESSAGE;
@@ -629,7 +629,7 @@ static rtcm3_rc decode_string(swiftnav_bitstream_t *buff, u8 *len, char *str) {
   return RC_OK;
 }
 
-static rtcm3_rc rtcm3_decode_1007_base(swiftnav_bitstream_t *buff,
+static rtcm3_rc rtcm3_decode_1007_base(swiftnav_in_bitstream_t *buff,
                                        rtcm_msg_1007 *msg_1007) {
   BITSTREAM_DECODE_U16(buff, msg_1007->stn_id, 12);
   if (decode_string(buff,
@@ -651,7 +651,7 @@ static rtcm3_rc rtcm3_decode_1007_base(swiftnav_bitstream_t *buff,
  *          - RC_INVALID_MESSAGE : String length too large
  *
  */
-rtcm3_rc rtcm3_decode_1007_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1007_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1007 *msg_1007) {
   assert(msg_1007);
   uint32_t msg_num;
@@ -672,7 +672,7 @@ rtcm3_rc rtcm3_decode_1007_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : String length too large
  */
-rtcm3_rc rtcm3_decode_1008_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1008_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1008 *msg_1008) {
   assert(msg_1008);
   uint32_t msg_num;
@@ -699,7 +699,7 @@ rtcm3_rc rtcm3_decode_1008_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : TOW sanity check fail
  */
-rtcm3_rc rtcm3_decode_1010_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1010_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1010) {
   assert(msg_1010);
   rtcm3_rc ret = rtcm3_read_glo_header(buff, &msg_1010->header);
@@ -759,7 +759,7 @@ rtcm3_rc rtcm3_decode_1010_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : TOW sanity check fail
  */
-rtcm3_rc rtcm3_decode_1012_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1012_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_obs_message *msg_1012) {
   assert(msg_1012);
   rtcm3_rc ret = rtcm3_read_glo_header(buff, &msg_1012->header);
@@ -838,7 +838,7 @@ rtcm3_rc rtcm3_decode_1012_bitstream(swiftnav_bitstream_t *buff,
  * \return  - RC_OK : Success
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  */
-rtcm3_rc rtcm3_decode_1029_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1029_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1029 *msg_1029) {
   assert(msg_1029);
   uint32_t msg_num;
@@ -872,7 +872,7 @@ rtcm3_rc rtcm3_decode_1029_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : String length too large
  */
-rtcm3_rc rtcm3_decode_1033_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1033_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1033 *msg_1033) {
   assert(msg_1033);
   uint32_t msg_num;
@@ -929,7 +929,7 @@ rtcm3_rc rtcm3_decode_1033_bitstream(swiftnav_bitstream_t *buff,
  * \return  - RC_OK : Success
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  */
-rtcm3_rc rtcm3_decode_1230_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_1230_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_1230 *msg_1230) {
   assert(msg_1230);
   uint32_t msg_num;
@@ -942,7 +942,7 @@ rtcm3_rc rtcm3_decode_1230_bitstream(swiftnav_bitstream_t *buff,
   BITSTREAM_DECODE_U16(buff, msg_1230->stn_id, 12);
   BITSTREAM_DECODE_U8(buff, msg_1230->bias_indicator, 1);
   /* 3 Reserved bits */
-  swiftnav_bitstream_remove(buff, 3);
+  swiftnav_in_bitstream_remove(buff, 3);
   BITSTREAM_DECODE_U8(buff, msg_1230->fdma_signal_mask, 4);
   if (msg_1230->fdma_signal_mask & 0x08) {
     s32 tmp;
@@ -976,7 +976,7 @@ rtcm3_rc rtcm3_decode_1230_bitstream(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_msm_sat_data(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_msm_sat_data(swiftnav_in_bitstream_t *buff,
                                     const uint8_t num_sats,
                                     const msm_enum msm_type,
                                     double rough_range_ms[],
@@ -1029,7 +1029,7 @@ static rtcm3_rc decode_msm_sat_data(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_msm_fine_pseudoranges(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_msm_fine_pseudoranges(swiftnav_in_bitstream_t *buff,
                                              const uint8_t num_cells,
                                              double fine_pr_ms[],
                                              flag_bf flags[]) {
@@ -1044,7 +1044,7 @@ static rtcm3_rc decode_msm_fine_pseudoranges(swiftnav_bitstream_t *buff,
 }
 
 static rtcm3_rc decode_msm_fine_pseudoranges_extended(
-    swiftnav_bitstream_t *buff,
+    swiftnav_in_bitstream_t *buff,
     const uint8_t num_cells,
     double fine_pr_ms[],
     flag_bf flags[]) {
@@ -1058,7 +1058,7 @@ static rtcm3_rc decode_msm_fine_pseudoranges_extended(
   return RC_OK;
 }
 
-static rtcm3_rc decode_msm_fine_phaseranges(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_msm_fine_phaseranges(swiftnav_in_bitstream_t *buff,
                                             const uint8_t num_cells,
                                             double fine_cp_ms[],
                                             flag_bf flags[]) {
@@ -1072,7 +1072,7 @@ static rtcm3_rc decode_msm_fine_phaseranges(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_msm_fine_phaseranges_extended(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_msm_fine_phaseranges_extended(swiftnav_in_bitstream_t *buff,
                                                      const uint8_t num_cells,
                                                      double fine_cp_ms[],
                                                      flag_bf flags[]) {
@@ -1086,7 +1086,7 @@ static rtcm3_rc decode_msm_fine_phaseranges_extended(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_msm_lock_times(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_msm_lock_times(swiftnav_in_bitstream_t *buff,
                                       const uint8_t num_cells,
                                       double lock_time[],
                                       flag_bf flags[]) {
@@ -1100,7 +1100,7 @@ static rtcm3_rc decode_msm_lock_times(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_msm_lock_times_extended(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_msm_lock_times_extended(swiftnav_in_bitstream_t *buff,
                                                const uint8_t num_cells,
                                                double lock_time[],
                                                flag_bf flags[]) {
@@ -1114,7 +1114,7 @@ static rtcm3_rc decode_msm_lock_times_extended(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_msm_hca_indicators(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_msm_hca_indicators(swiftnav_in_bitstream_t *buff,
                                           const uint8_t num_cells,
                                           bool hca_indicator[]) {
   /* DF420 */
@@ -1124,7 +1124,7 @@ static rtcm3_rc decode_msm_hca_indicators(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_msm_cnrs(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_msm_cnrs(swiftnav_in_bitstream_t *buff,
                                 const uint8_t num_cells,
                                 double cnr[],
                                 flag_bf flags[]) {
@@ -1138,7 +1138,7 @@ static rtcm3_rc decode_msm_cnrs(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_msm_cnrs_extended(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_msm_cnrs_extended(swiftnav_in_bitstream_t *buff,
                                          const uint8_t num_cells,
                                          double cnr[],
                                          flag_bf flags[]) {
@@ -1152,7 +1152,7 @@ static rtcm3_rc decode_msm_cnrs_extended(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_msm_fine_phaserangerates(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_msm_fine_phaserangerates(swiftnav_in_bitstream_t *buff,
                                                 const uint8_t num_cells,
                                                 double *fine_range_rate_m_s,
                                                 flag_bf *flags) {
@@ -1175,7 +1175,7 @@ static rtcm3_rc decode_msm_fine_phaserangerates(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : Cell mask too large or invalid TOW
  */
-static rtcm3_rc rtcm3_decode_msm_internal(swiftnav_bitstream_t *buff,
+static rtcm3_rc rtcm3_decode_msm_internal(swiftnav_in_bitstream_t *buff,
                                           const uint16_t msm_type,
                                           rtcm_msm_message *msg) {
   if (MSM4 != msm_type && MSM5 != msm_type && MSM6 != msm_type &&
@@ -1388,7 +1388,7 @@ static rtcm3_rc rtcm3_decode_msm_internal(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : Cell mask too large or invalid TOW
  */
-rtcm3_rc rtcm3_decode_msm4_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_msm4_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msm_message *msg) {
   assert(msg);
   return rtcm3_decode_msm_internal(buff, MSM4, msg);
@@ -1402,7 +1402,7 @@ rtcm3_rc rtcm3_decode_msm4_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : Cell mask too large or invalid TOW
  */
-rtcm3_rc rtcm3_decode_msm5_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_msm5_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msm_message *msg) {
   assert(msg);
   return rtcm3_decode_msm_internal(buff, MSM5, msg);
@@ -1416,7 +1416,7 @@ rtcm3_rc rtcm3_decode_msm5_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : Cell mask too large or invalid TOW
  */
-rtcm3_rc rtcm3_decode_msm6_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_msm6_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msm_message *msg) {
   assert(msg);
   return rtcm3_decode_msm_internal(buff, MSM6, msg);
@@ -1430,7 +1430,7 @@ rtcm3_rc rtcm3_decode_msm6_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : Cell mask too large or invalid TOW
  */
-rtcm3_rc rtcm3_decode_msm7_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_msm7_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msm_message *msg) {
   assert(msg);
   return rtcm3_decode_msm_internal(buff, MSM7, msg);
@@ -1444,7 +1444,7 @@ rtcm3_rc rtcm3_decode_msm7_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : Nonzero reserved bits (invalid format)
  */
-rtcm3_rc rtcm3_decode_4062_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_4062_bitstream(swiftnav_in_bitstream_t *buff,
                                      rtcm_msg_swift_proprietary *msg) {
   assert(msg);
   uint32_t msg_num;

--- a/c/librtcm/src/decode.c
+++ b/c/librtcm/src/decode.c
@@ -16,11 +16,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "decode_helpers.h"
 #include "rtcm3/bits.h"
 #include "rtcm3/eph_decode.h"
 #include "rtcm3/msm_utils.h"
-
-#include "decode_helpers.h"
 
 static void init_sat_data(rtcm_sat_data *sat_data) {
   for (uint8_t freq = 0; freq < NUM_FREQS; ++freq) {
@@ -298,7 +297,8 @@ static uint8_t construct_L2_phase(rtcm_freq_data *l2_freq_data,
   return 0;
 }
 
-static rtcm3_rc get_cnr(rtcm_freq_data *freq_data, swiftnav_in_bitstream_t *buff) {
+static rtcm3_rc get_cnr(rtcm_freq_data *freq_data,
+                        swiftnav_in_bitstream_t *buff) {
   uint32_t cnr;
   BITSTREAM_DECODE_U32(buff, cnr, 8);
   if (cnr == 0) {
@@ -618,7 +618,9 @@ rtcm3_rc rtcm3_decode_1006_bitstream(swiftnav_in_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_string(swiftnav_in_bitstream_t *buff, u8 *len, char *str) {
+static rtcm3_rc decode_string(swiftnav_in_bitstream_t *buff,
+                              u8 *len,
+                              char *str) {
   BITSTREAM_DECODE_U8(buff, *len, 8);
   if (*len > RTCM_MAX_STRING_LEN) {
     return RC_INVALID_MESSAGE;
@@ -1072,10 +1074,11 @@ static rtcm3_rc decode_msm_fine_phaseranges(swiftnav_in_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_msm_fine_phaseranges_extended(swiftnav_in_bitstream_t *buff,
-                                                     const uint8_t num_cells,
-                                                     double fine_cp_ms[],
-                                                     flag_bf flags[]) {
+static rtcm3_rc decode_msm_fine_phaseranges_extended(
+    swiftnav_in_bitstream_t *buff,
+    const uint8_t num_cells,
+    double fine_cp_ms[],
+    flag_bf flags[]) {
   /* DF406 */
   for (uint16_t i = 0; i < num_cells; i++) {
     int32_t decoded;

--- a/c/librtcm/src/decode_helpers.h
+++ b/c/librtcm/src/decode_helpers.h
@@ -16,11 +16,11 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_bitstream_getbitul(                                          \
+    if (!swiftnav_in_bitstream_getbitul(                                          \
             bitstream, &decode_u64_temp, 0, n_bits)) {                         \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
     (field) = decode_u64_temp;                                                 \
   } while (false)
 
@@ -32,11 +32,11 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_bitstream_getbitsl(                                          \
+    if (!swiftnav_in_bitstream_getbitsl(                                          \
             bitstream, &decode_s64_temp, 0, n_bits)) {                         \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
     (field) = decode_s64_temp;                                                 \
   } while (false)
 
@@ -48,10 +48,10 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_bitstream_getbitu(bitstream, &decode_u32_temp, 0, n_bits)) { \
+    if (!swiftnav_in_bitstream_getbitu(bitstream, &decode_u32_temp, 0, n_bits)) { \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
     (field) = decode_u32_temp;                                                 \
   } while (false)
 
@@ -63,10 +63,10 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_bitstream_getbits(bitstream, &decode_s32_temp, 0, n_bits)) { \
+    if (!swiftnav_in_bitstream_getbits(bitstream, &decode_s32_temp, 0, n_bits)) { \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
     (field) = decode_s32_temp;                                                 \
   } while (false)
 
@@ -78,10 +78,10 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_bitstream_getbitu(bitstream, &decode_u16_temp, 0, n_bits)) { \
+    if (!swiftnav_in_bitstream_getbitu(bitstream, &decode_u16_temp, 0, n_bits)) { \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
     (field) = decode_u16_temp;                                                 \
   } while (false)
 
@@ -93,10 +93,10 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_bitstream_getbits(bitstream, &decode_s16_temp, 0, n_bits)) { \
+    if (!swiftnav_in_bitstream_getbits(bitstream, &decode_s16_temp, 0, n_bits)) { \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
     (field) = decode_s16_temp;                                                 \
   } while (false)
 
@@ -108,10 +108,10 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_bitstream_getbitu(bitstream, &decode_u8_temp, 0, n_bits)) {  \
+    if (!swiftnav_in_bitstream_getbitu(bitstream, &decode_u8_temp, 0, n_bits)) {  \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
     (field) = decode_u8_temp;                                                  \
   } while (false)
 
@@ -123,10 +123,10 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_bitstream_getbits(bitstream, &decode_s8_temp, 0, n_bits)) {  \
+    if (!swiftnav_in_bitstream_getbits(bitstream, &decode_s8_temp, 0, n_bits)) {  \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
     (field) = decode_s8_temp;                                                  \
   } while (false)
 

--- a/c/librtcm/src/decode_helpers.h
+++ b/c/librtcm/src/decode_helpers.h
@@ -16,11 +16,11 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_in_bitstream_getbitul(                                          \
+    if (!swiftnav_in_bitstream_getbitul(                                       \
             bitstream, &decode_u64_temp, 0, n_bits)) {                         \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                           \
     (field) = decode_u64_temp;                                                 \
   } while (false)
 
@@ -32,11 +32,11 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_in_bitstream_getbitsl(                                          \
+    if (!swiftnav_in_bitstream_getbitsl(                                       \
             bitstream, &decode_s64_temp, 0, n_bits)) {                         \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                           \
     (field) = decode_s64_temp;                                                 \
   } while (false)
 
@@ -48,10 +48,11 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_in_bitstream_getbitu(bitstream, &decode_u32_temp, 0, n_bits)) { \
+    if (!swiftnav_in_bitstream_getbitu(                                        \
+            bitstream, &decode_u32_temp, 0, n_bits)) {                         \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                           \
     (field) = decode_u32_temp;                                                 \
   } while (false)
 
@@ -63,10 +64,11 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_in_bitstream_getbits(bitstream, &decode_s32_temp, 0, n_bits)) { \
+    if (!swiftnav_in_bitstream_getbits(                                        \
+            bitstream, &decode_s32_temp, 0, n_bits)) {                         \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                           \
     (field) = decode_s32_temp;                                                 \
   } while (false)
 
@@ -78,10 +80,11 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_in_bitstream_getbitu(bitstream, &decode_u16_temp, 0, n_bits)) { \
+    if (!swiftnav_in_bitstream_getbitu(                                        \
+            bitstream, &decode_u16_temp, 0, n_bits)) {                         \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                           \
     (field) = decode_u16_temp;                                                 \
   } while (false)
 
@@ -93,10 +96,11 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_in_bitstream_getbits(bitstream, &decode_s16_temp, 0, n_bits)) { \
+    if (!swiftnav_in_bitstream_getbits(                                        \
+            bitstream, &decode_s16_temp, 0, n_bits)) {                         \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                           \
     (field) = decode_s16_temp;                                                 \
   } while (false)
 
@@ -108,10 +112,11 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_in_bitstream_getbitu(bitstream, &decode_u8_temp, 0, n_bits)) {  \
+    if (!swiftnav_in_bitstream_getbitu(                                        \
+            bitstream, &decode_u8_temp, 0, n_bits)) {                          \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                           \
     (field) = decode_u8_temp;                                                  \
   } while (false)
 
@@ -123,10 +128,11 @@
         __decode_assert_2[((size_t)(n_bits) <= (sizeof(field) * 8)) ? 1 : -1]; \
     (void)__decode_assert_1;                                                   \
     (void)__decode_assert_2;                                                   \
-    if (!swiftnav_in_bitstream_getbits(bitstream, &decode_s8_temp, 0, n_bits)) {  \
+    if (!swiftnav_in_bitstream_getbits(                                        \
+            bitstream, &decode_s8_temp, 0, n_bits)) {                          \
       return RC_INVALID_MESSAGE;                                               \
     }                                                                          \
-    swiftnav_in_bitstream_remove(bitstream, n_bits);                              \
+    swiftnav_in_bitstream_remove(bitstream, n_bits);                           \
     (field) = decode_s8_temp;                                                  \
   } while (false)
 

--- a/c/librtcm/src/eph_decode.c
+++ b/c/librtcm/src/eph_decode.c
@@ -24,7 +24,7 @@
  * \return  - RC_OK : Success
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  */
-rtcm3_rc rtcm3_decode_gps_eph_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_gps_eph_bitstream(swiftnav_in_bitstream_t *buff,
                                         rtcm_msg_eph *msg_eph) {
   assert(msg_eph);
   memset(msg_eph, 0, sizeof(*msg_eph));
@@ -77,7 +77,7 @@ rtcm3_rc rtcm3_decode_gps_eph_bitstream(swiftnav_bitstream_t *buff,
  * \return  - RC_OK : Success
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  */
-rtcm3_rc rtcm3_decode_qzss_eph_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_qzss_eph_bitstream(swiftnav_in_bitstream_t *buff,
                                          rtcm_msg_eph *msg_eph) {
   assert(msg_eph);
   memset(msg_eph, 0, sizeof(*msg_eph));
@@ -110,7 +110,7 @@ rtcm3_rc rtcm3_decode_qzss_eph_bitstream(swiftnav_bitstream_t *buff,
   BITSTREAM_DECODE_S32(buff, msg_eph->data.kepler.omegadot, 24);
   BITSTREAM_DECODE_S16(buff, msg_eph->data.kepler.inc_dot, 14);
   /* L2 data bit */
-  swiftnav_bitstream_remove(buff, 2);
+  swiftnav_in_bitstream_remove(buff, 2);
   BITSTREAM_DECODE_U16(buff, msg_eph->wn, 10);
   BITSTREAM_DECODE_U16(buff, msg_eph->ura, 4);
   BITSTREAM_DECODE_U8(buff, msg_eph->health_bits, 6);
@@ -127,7 +127,7 @@ rtcm3_rc rtcm3_decode_qzss_eph_bitstream(swiftnav_bitstream_t *buff,
  * \return  - RC_OK : Success
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  */
-rtcm3_rc rtcm3_decode_glo_eph_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_glo_eph_bitstream(swiftnav_in_bitstream_t *buff,
                                         rtcm_msg_eph *msg_eph) {
   assert(msg_eph);
   memset(msg_eph, 0, sizeof(*msg_eph));
@@ -140,17 +140,17 @@ rtcm3_rc rtcm3_decode_glo_eph_bitstream(swiftnav_bitstream_t *buff,
   BITSTREAM_DECODE_U8(buff, msg_eph->sat_id, 6);
   BITSTREAM_DECODE_U8(buff, msg_eph->data.glo.fcn, 5);
   /*alm health ind = */
-  swiftnav_bitstream_remove(buff, 1);
+  swiftnav_in_bitstream_remove(buff, 1);
   /*alm health ind valid = */
-  swiftnav_bitstream_remove(buff, 1);
+  swiftnav_in_bitstream_remove(buff, 1);
   BITSTREAM_DECODE_U32(buff, msg_eph->fit_interval, 2);
   /* tk */
-  swiftnav_bitstream_remove(buff, 12);
+  swiftnav_in_bitstream_remove(buff, 12);
   /* most significant bit of Bn */
   uint8_t bn_msb;
   BITSTREAM_DECODE_U8(buff, bn_msb, 1);
   /* P2 */
-  swiftnav_bitstream_remove(buff, 1);
+  swiftnav_in_bitstream_remove(buff, 1);
   BITSTREAM_DECODE_U8(buff, msg_eph->data.glo.t_b, 7);
   rtcm3_rc ret =
       rtcm_get_sign_magnitude_bitstream(buff, 24, &msg_eph->data.glo.vel[0]);
@@ -190,7 +190,7 @@ rtcm3_rc rtcm3_decode_glo_eph_bitstream(swiftnav_bitstream_t *buff,
     return ret;
   }
   /* P3 */
-  swiftnav_bitstream_remove(buff, 1);
+  swiftnav_in_bitstream_remove(buff, 1);
   s32 gamma;
   ret = rtcm_get_sign_magnitude_bitstream(buff, 11, &gamma);
   if (ret != RC_OK) {
@@ -198,7 +198,7 @@ rtcm3_rc rtcm3_decode_glo_eph_bitstream(swiftnav_bitstream_t *buff,
   }
   msg_eph->data.glo.gamma = (s16)gamma;
   /* P */
-  swiftnav_bitstream_remove(buff, 2);
+  swiftnav_in_bitstream_remove(buff, 2);
   /* health flag in string 3 */
   uint8_t mln3;
   BITSTREAM_DECODE_U8(buff, mln3, 1);
@@ -213,30 +213,30 @@ rtcm3_rc rtcm3_decode_glo_eph_bitstream(swiftnav_bitstream_t *buff,
   }
   msg_eph->data.glo.d_tau = (uint8_t)d_tau;
   /* EN */
-  swiftnav_bitstream_remove(buff, 5);
+  swiftnav_in_bitstream_remove(buff, 5);
   /* P4 */
-  swiftnav_bitstream_remove(buff, 1);
+  swiftnav_in_bitstream_remove(buff, 1);
   BITSTREAM_DECODE_U16(buff, msg_eph->ura, 4);
   /* NT */
-  swiftnav_bitstream_remove(buff, 11);
+  swiftnav_in_bitstream_remove(buff, 11);
   /* M */
-  swiftnav_bitstream_remove(buff, 2);
+  swiftnav_in_bitstream_remove(buff, 2);
   uint32_t additional_data;
   BITSTREAM_DECODE_U32(buff, additional_data, 1);
   uint8_t mln5 = 0;
   if (additional_data) {
     /* NA  */
-    swiftnav_bitstream_remove(buff, 11);
+    swiftnav_in_bitstream_remove(buff, 11);
     /* Tc */
-    swiftnav_bitstream_remove(buff, 32);
+    swiftnav_in_bitstream_remove(buff, 32);
     /* N4 */
-    swiftnav_bitstream_remove(buff, 5);
+    swiftnav_in_bitstream_remove(buff, 5);
     /* Tgps */
-    swiftnav_bitstream_remove(buff, 22);
+    swiftnav_in_bitstream_remove(buff, 22);
     /* health flag in string 5 */
     BITSTREAM_DECODE_U8(buff, mln5, 1);
     /* reserved */
-    swiftnav_bitstream_remove(buff, 7);
+    swiftnav_in_bitstream_remove(buff, 7);
   }
   msg_eph->health_bits = bn_msb | mln3 | mln5;
   return RC_OK;
@@ -250,7 +250,7 @@ rtcm3_rc rtcm3_decode_glo_eph_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : Satellite is geostationary
  */
-rtcm3_rc rtcm3_decode_bds_eph_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_bds_eph_bitstream(swiftnav_in_bitstream_t *buff,
                                         rtcm_msg_eph *msg_eph) {
   assert(msg_eph);
   memset(msg_eph, 0, sizeof(*msg_eph));
@@ -301,7 +301,7 @@ rtcm3_rc rtcm3_decode_bds_eph_bitstream(swiftnav_bitstream_t *buff,
  * \param msg_eph RTCM message struct
  * \return bit position in the RTCM frame
  */
-static uint16_t rtcm3_decode_gal_eph_common(swiftnav_bitstream_t *buff,
+static uint16_t rtcm3_decode_gal_eph_common(swiftnav_in_bitstream_t *buff,
                                             rtcm_msg_eph *msg_eph) {
   assert(msg_eph);
   BITSTREAM_DECODE_U8(buff, msg_eph->sat_id, 6);
@@ -338,7 +338,7 @@ static uint16_t rtcm3_decode_gal_eph_common(swiftnav_bitstream_t *buff,
  * \return  - RC_OK : Success
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  */
-rtcm3_rc rtcm3_decode_gal_eph_inav_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_gal_eph_inav_bitstream(swiftnav_in_bitstream_t *buff,
                                              rtcm_msg_eph *msg_eph) {
   assert(msg_eph);
   memset(msg_eph, 0, sizeof(*msg_eph));
@@ -359,7 +359,7 @@ rtcm3_rc rtcm3_decode_gal_eph_inav_bitstream(swiftnav_bitstream_t *buff,
   BITSTREAM_DECODE_S32(buff, msg_eph->data.kepler.tgd.gal_s[1], 10);
   BITSTREAM_DECODE_S8(buff, msg_eph->health_bits, 6);
   /* reserved */
-  swiftnav_bitstream_remove(buff, 2);
+  swiftnav_in_bitstream_remove(buff, 2);
 
   return RC_OK;
 }
@@ -371,7 +371,7 @@ rtcm3_rc rtcm3_decode_gal_eph_inav_bitstream(swiftnav_bitstream_t *buff,
  * \return  - RC_OK : Success
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  */
-rtcm3_rc rtcm3_decode_gal_eph_fnav_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_gal_eph_fnav_bitstream(swiftnav_in_bitstream_t *buff,
                                              rtcm_msg_eph *msg_eph) {
   assert(msg_eph);
   memset(msg_eph, 0, sizeof(*msg_eph));
@@ -392,7 +392,7 @@ rtcm3_rc rtcm3_decode_gal_eph_fnav_bitstream(swiftnav_bitstream_t *buff,
   msg_eph->data.kepler.tgd.gal_s[1] = 0;
   BITSTREAM_DECODE_S8(buff, msg_eph->health_bits, 3);
   /* reserved */
-  swiftnav_bitstream_remove(buff, 7);
+  swiftnav_in_bitstream_remove(buff, 7);
 
   return RC_OK;
 }

--- a/c/librtcm/src/eph_decode.c
+++ b/c/librtcm/src/eph_decode.c
@@ -11,11 +11,12 @@
  */
 
 #include "rtcm3/eph_decode.h"
+
 #include <assert.h>
 #include <string.h>
-#include "rtcm3/bits.h"
 
 #include "decode_helpers.h"
+#include "rtcm3/bits.h"
 
 /** Decode an RTCMv3 GPS Ephemeris Message
  *

--- a/c/librtcm/src/eph_encode.c
+++ b/c/librtcm/src/eph_encode.c
@@ -11,8 +11,10 @@
  */
 
 #include "rtcm3/eph_encode.h"
+
 #include <assert.h>
 #include <string.h>
+
 #include "rtcm3/bits.h"
 
 uint16_t rtcm3_encode_gps_eph(const rtcm_msg_eph *msg_1019, uint8_t buff[]) {

--- a/c/librtcm/src/logging.c
+++ b/c/librtcm/src/logging.c
@@ -10,9 +10,8 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <stdlib.h>
-
 #include <rtcm3/logging.h>
+#include <stdlib.h>
 
 static rtcm_log_callback log_callback_ = NULL;
 static void *log_context_ = NULL;

--- a/c/librtcm/src/ssr_decode.c
+++ b/c/librtcm/src/ssr_decode.c
@@ -11,13 +11,14 @@
  */
 
 #include "rtcm3/ssr_decode.h"
+
 #include <assert.h>
 #include <stdio.h>
+
+#include "decode_helpers.h"
 #include "rtcm3/bits.h"
 #include "rtcm3/msm_utils.h"
 #include "swiftnav/bitstream.h"
-
-#include "decode_helpers.h"
 
 /** Get the numbers of bits for the  Epoch Time 1s field
  * \param constellation Message constellation

--- a/c/librtcm/src/ssr_decode.c
+++ b/c/librtcm/src/ssr_decode.c
@@ -143,7 +143,7 @@ bool is_ssr_phase_biases_message(const uint16_t message_num) {
   return message_num >= 1265 && message_num <= 1270;
 }
 
-enum rtcm3_rc_e decode_ssr_header(swiftnav_bitstream_t *buff,
+enum rtcm3_rc_e decode_ssr_header(swiftnav_in_bitstream_t *buff,
                                   rtcm_msg_ssr_header *msg_header) {
   assert(msg_header);
   BITSTREAM_DECODE_U16(buff, msg_header->message_num, 12);
@@ -173,7 +173,7 @@ enum rtcm3_rc_e decode_ssr_header(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_ssr_orbit(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_ssr_orbit(swiftnav_in_bitstream_t *buff,
                                  uint8_t constellation,
                                  rtcm_msg_ssr_orbit_corr *orbit) {
   uint8_t number_of_bits_for_iode;
@@ -208,7 +208,7 @@ static rtcm3_rc decode_ssr_orbit(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_ssr_clock(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_ssr_clock(swiftnav_in_bitstream_t *buff,
                                  rtcm_msg_ssr_clock_corr *clock) {
   BITSTREAM_DECODE_S32(buff, clock->c0, 22);
   BITSTREAM_DECODE_S32(buff, clock->c1, 21);
@@ -216,7 +216,7 @@ static rtcm3_rc decode_ssr_clock(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-static rtcm3_rc decode_satellite_id(swiftnav_bitstream_t *buff,
+static rtcm3_rc decode_satellite_id(swiftnav_in_bitstream_t *buff,
                                     uint8_t constellation,
                                     uint8_t *sat_id) {
   uint8_t number_of_bits_for_sat_id;
@@ -230,7 +230,7 @@ static rtcm3_rc decode_satellite_id(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-rtcm3_rc rtcm3_decode_orbit_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_orbit_bitstream(swiftnav_in_bitstream_t *buff,
                                       rtcm_msg_orbit *msg_orbit) {
   assert(msg_orbit);
   if (!(RC_OK == decode_ssr_header(buff, &msg_orbit->header))) {
@@ -260,7 +260,7 @@ rtcm3_rc rtcm3_decode_orbit_bitstream(swiftnav_bitstream_t *buff,
   return RC_OK;
 }
 
-rtcm3_rc rtcm3_decode_clock_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_clock_bitstream(swiftnav_in_bitstream_t *buff,
                                       rtcm_msg_clock *msg_clock) {
   assert(msg_clock);
   if (!(RC_OK == decode_ssr_header(buff, &msg_clock->header))) {
@@ -295,7 +295,7 @@ rtcm3_rc rtcm3_decode_clock_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_INVALID_MESSAGE : Unknown constellation
  */
 rtcm3_rc rtcm3_decode_orbit_clock_bitstream(
-    swiftnav_bitstream_t *buff, rtcm_msg_orbit_clock *msg_orbit_clock) {
+    swiftnav_in_bitstream_t *buff, rtcm_msg_orbit_clock *msg_orbit_clock) {
   assert(msg_orbit_clock);
   if (!(RC_OK == decode_ssr_header(buff, &msg_orbit_clock->header))) {
     return RC_INVALID_MESSAGE;
@@ -336,7 +336,7 @@ rtcm3_rc rtcm3_decode_orbit_clock_bitstream(
  *          - RC_MESSAGE_TYPE_MISMATCH : Message type mismatch
  *          - RC_INVALID_MESSAGE : Unknown constellation
  */
-rtcm3_rc rtcm3_decode_code_bias_bitstream(swiftnav_bitstream_t *buff,
+rtcm3_rc rtcm3_decode_code_bias_bitstream(swiftnav_in_bitstream_t *buff,
                                           rtcm_msg_code_bias *msg_code_bias) {
   assert(msg_code_bias);
   if (!(RC_OK == decode_ssr_header(buff, &msg_code_bias->header))) {
@@ -378,7 +378,7 @@ rtcm3_rc rtcm3_decode_code_bias_bitstream(swiftnav_bitstream_t *buff,
  *          - RC_INVALID_MESSAGE : Unknown constellation
  */
 rtcm3_rc rtcm3_decode_phase_bias_bitstream(
-    swiftnav_bitstream_t *buff, rtcm_msg_phase_bias *msg_phase_bias) {
+    swiftnav_in_bitstream_t *buff, rtcm_msg_phase_bias *msg_phase_bias) {
   assert(msg_phase_bias);
   if (!(RC_OK == decode_ssr_header(buff, &msg_phase_bias->header))) {
     return RC_INVALID_MESSAGE;

--- a/c/librtcm/test/rtcm_decoder_tests.c
+++ b/c/librtcm/test/rtcm_decoder_tests.c
@@ -11,11 +11,13 @@
  */
 
 #include "rtcm_decoder_tests.h"
+
 #include <math.h>
 #include <rtcm3/messages.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "rtcm3/bits.h"
 #include "rtcm3/decode.h"
 #include "rtcm3/encode.h"
@@ -26,7 +28,6 @@
 
 #define LIBRTCM_LOG_INTERNAL
 #include "rtcm3/logging.h"
-
 #include "test_assert.h"
 
 int main(void) {

--- a/c/librtcm/test/sta_rtcm3_tests.c
+++ b/c/librtcm/test/sta_rtcm3_tests.c
@@ -26,7 +26,6 @@
 #define DEBUG 0
 #define LIBRTCM_LOG_INTERNAL
 #include "rtcm3/logging.h"
-
 #include "test_assert.h"
 
 static uint8_t fw_ver_array[] = {

--- a/c/libubx/src/encode.c
+++ b/c/libubx/src/encode.c
@@ -16,10 +16,8 @@
  */
 
 #include <string.h>
-
-#include <ubx/encode.h>
-
 #include <swiftnav/bits.h>
+#include <ubx/encode.h>
 
 // UBX protocol is little-endian.
 

--- a/c/libubx/test/check_ubx.c
+++ b/c/libubx/test/check_ubx.c
@@ -10,18 +10,17 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include "check_suites.h"
-
-#include <ubx/decode.h>
-#include <ubx/encode.h>
-#include <ubx/ubx_messages.h>
-
 #include <assert.h>
 #include <check.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ubx/decode.h>
+#include <ubx/encode.h>
+#include <ubx/ubx_messages.h>
+
+#include "check_suites.h"
 
 #define FLOAT_EPS 1e-6
 

--- a/c/nov2sbp/parser/binary_header.cc
+++ b/c/nov2sbp/parser/binary_header.cc
@@ -11,6 +11,7 @@
  */
 
 #include "binary_header.h"
+
 #include "read_little_endian.h"
 
 namespace Novatel {

--- a/c/nov2sbp/parser/catch/catch.hpp
+++ b/c/nov2sbp/parser/catch/catch.hpp
@@ -2534,6 +2534,7 @@ class Section : NonCopyable {
 #define TWOBLUECUBES_CATCH_GENERATORS_HPP_INCLUDED
 
 #include <stdlib.h>
+
 #include <string>
 #include <vector>
 
@@ -6181,6 +6182,7 @@ inline Option<std::size_t> list(Config const &config) {
 #define TWOBLUECUBES_CATCH_TEST_CASE_TRACKER_HPP_INCLUDED
 
 #include <assert.h>
+
 #include <algorithm>
 #include <stdexcept>
 #include <string>
@@ -7138,6 +7140,7 @@ inline Version libraryVersion();
 }  // namespace Catch
 
 #include <stdlib.h>
+
 #include <fstream>
 #include <limits>
 
@@ -9655,6 +9658,7 @@ Ptr<IStreamingReporter> addReporter(
 #define TWOBLUECUBES_CATCH_REPORTER_BASES_HPP_INCLUDED
 
 #include <assert.h>
+
 #include <cfloat>
 #include <cstdio>
 #include <cstring>

--- a/c/nov2sbp/parser/message.h
+++ b/c/nov2sbp/parser/message.h
@@ -13,10 +13,10 @@
 #ifndef NOVATEL_PARSER_MESSAGE_H_
 #define NOVATEL_PARSER_MESSAGE_H_
 
-#include "binary_header.h"
-
 #include <array>
 #include <functional>
+
+#include "binary_header.h"
 
 namespace Novatel {
 namespace Message {

--- a/c/nov2sbp/parser/message_bestpos.cc
+++ b/c/nov2sbp/parser/message_bestpos.cc
@@ -11,9 +11,10 @@
  */
 
 #include "message_bestpos.h"
-#include "read_little_endian.h"
 
 #include <cassert>
+
+#include "read_little_endian.h"
 
 namespace Novatel {
 

--- a/c/nov2sbp/parser/message_bestvel.cc
+++ b/c/nov2sbp/parser/message_bestvel.cc
@@ -1,7 +1,8 @@
 #include "message_bestvel.h"
-#include "read_little_endian.h"
 
 #include <cassert>
+
+#include "read_little_endian.h"
 
 namespace Novatel {
 

--- a/c/nov2sbp/parser/message_gloephemeris.cc
+++ b/c/nov2sbp/parser/message_gloephemeris.cc
@@ -11,9 +11,10 @@
  */
 
 #include "message_gloephemeris.h"
-#include "read_little_endian.h"
 
 #include <cassert>
+
+#include "read_little_endian.h"
 
 namespace Novatel {
 

--- a/c/nov2sbp/parser/message_gpsephem.cc
+++ b/c/nov2sbp/parser/message_gpsephem.cc
@@ -11,9 +11,10 @@
  */
 
 #include "message_gpsephem.h"
-#include "read_little_endian.h"
 
 #include <cassert>
+
+#include "read_little_endian.h"
 
 namespace Novatel {
 

--- a/c/nov2sbp/parser/message_insatt.cc
+++ b/c/nov2sbp/parser/message_insatt.cc
@@ -11,9 +11,10 @@
  */
 
 #include "message_insatt.h"
-#include "read_little_endian.h"
 
 #include <cassert>
+
+#include "read_little_endian.h"
 
 namespace Novatel {
 

--- a/c/nov2sbp/parser/message_rangecmp.cc
+++ b/c/nov2sbp/parser/message_rangecmp.cc
@@ -11,9 +11,10 @@
  */
 
 #include "message_rangecmp.h"
-#include "read_little_endian.h"
 
 #include <cassert>
+
+#include "read_little_endian.h"
 
 namespace Novatel {
 

--- a/c/nov2sbp/parser/message_rawimusx.cc
+++ b/c/nov2sbp/parser/message_rawimusx.cc
@@ -11,9 +11,10 @@
  */
 
 #include "message_rawimusx.h"
-#include "read_little_endian.h"
 
 #include <cassert>
+
+#include "read_little_endian.h"
 
 namespace Novatel {
 

--- a/c/nov2sbp/parser/parser.cc
+++ b/c/nov2sbp/parser/parser.cc
@@ -11,9 +11,11 @@
  */
 
 #include "parser.h"
+
 #include <cstdarg>
 #include <cstdio>
 #include <cstring>
+
 #include "crc_checker.h"
 #include "message_bestpos.h"
 #include "message_bestvel.h"

--- a/c/nov2sbp/parser/parser.h
+++ b/c/nov2sbp/parser/parser.h
@@ -15,6 +15,7 @@
 
 #include <swiftnav/macros.h>
 #include <unistd.h>  // for size_t
+
 #include "binary_header.h"
 #include "message.h"
 

--- a/c/nov2sbp/parser/test_parser.cc
+++ b/c/nov2sbp/parser/test_parser.cc
@@ -10,13 +10,12 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include "catch/catch.hpp"
-#include "parser.h"
-
-#include "message_gloephemeris.h"
-
 #include <cassert>
 #include <cstdio>
+
+#include "catch/catch.hpp"
+#include "message_gloephemeris.h"
+#include "parser.h"
 
 static void logfn(const char *msg) { printf("%s\n", msg); }
 

--- a/c/nov2sbp/src/nov2sbp.cc
+++ b/c/nov2sbp/src/nov2sbp.cc
@@ -11,14 +11,14 @@
  */
 
 #include <swiftnav/logging.h>
-
-#include "parser/novatel.h"
-#include "swiftnav_conversion_helpers.h"
-
 #include <unistd.h>
+
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+
+#include "parser/novatel.h"
+#include "swiftnav_conversion_helpers.h"
 
 typedef int (*readfn_ptr)(uint8_t *, uint32_t, void *);
 typedef int (*writefn_ptr)(uint8_t *, uint32_t, void *);

--- a/c/nov2sbp/src/send_sbp_obs_messages.cc
+++ b/c/nov2sbp/src/send_sbp_obs_messages.cc
@@ -13,8 +13,6 @@
 /**
  * This implementation is entirely lifted from PFWP.
  */
-#include "swiftnav_conversion_helpers.h"
-
 #include <swiftnav/common.h>
 #include <swiftnav/constants.h>
 #include <swiftnav/gnss_time.h>
@@ -22,6 +20,8 @@
 #include <swiftnav/signal.h>
 
 #include <cassert>
+
+#include "swiftnav_conversion_helpers.h"
 
 namespace Novatel {
 

--- a/c/nov2sbp/src/swiftnav_conversion_helpers.cc
+++ b/c/nov2sbp/src/swiftnav_conversion_helpers.cc
@@ -10,11 +10,12 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <cmath>
-#include <string>
+#include "swiftnav_conversion_helpers.h"
 
 #include <swiftnav/geoid_model.h>
-#include "swiftnav_conversion_helpers.h"
+
+#include <cmath>
+#include <string>
 
 static const double kStandardGravity = 9.806;  // m/s^2
 static const uint32_t kMsPerWeek = 7 * 24 * 60 * 60 * 1000;

--- a/c/nov2sbp/src/swiftnav_conversion_helpers.h
+++ b/c/nov2sbp/src/swiftnav_conversion_helpers.h
@@ -22,17 +22,16 @@
  * type in either Swiftnav or SBP providing more or less a 1-to-1 match.
  */
 
-#include "parser/novatel.h"
-
-#include <swiftnav/gnss_time.h>
-#include <swiftnav/nav_meas.h>
-#include <swiftnav/pvt_result.h>
-
 #include <libsbp/legacy/imu.h>
 #include <libsbp/legacy/navigation.h>
 #include <libsbp/legacy/observation.h>
 #include <libsbp/legacy/orientation.h>
 #include <libsbp/sbp.h>
+#include <swiftnav/gnss_time.h>
+#include <swiftnav/nav_meas.h>
+#include <swiftnav/pvt_result.h>
+
+#include "parser/novatel.h"
 
 namespace Novatel {
 

--- a/c/rtcm3tosbp/test/check_rtcm3.c
+++ b/c/rtcm3tosbp/test/check_rtcm3.c
@@ -988,8 +988,8 @@ static s32 rtcm_gps_eph_cb(u8 *buffer, u16 length, void *context) {
   if (!checked_eph_gps && message_type == 1019) {
     checked_eph_gps = true;
     rtcm_msg_eph msg_eph;
-    swiftnav_bitstream_t bitstream;
-    swiftnav_bitstream_init(&bitstream, &buffer[byte], message_size * 8);
+    swiftnav_in_bitstream_t bitstream;
+    swiftnav_in_bitstream_init(&bitstream, &buffer[byte], message_size * 8);
     rtcm3_decode_gps_eph_bitstream(&bitstream, &msg_eph);
 
     ck_assert(msg_eph.constellation == RTCM_CONSTELLATION_GPS);
@@ -1047,8 +1047,8 @@ static s32 rtcm_gal_fnav_eph_cb(u8 *buffer, u16 length, void *context) {
     printf("GAL FNAV Eph checked\n");
     checked_eph_gal_fnav = true;
     rtcm_msg_eph msg_eph;
-    swiftnav_bitstream_t bitstream;
-    swiftnav_bitstream_init(&bitstream, &buffer[byte], message_size * 8);
+    swiftnav_in_bitstream_t bitstream;
+    swiftnav_in_bitstream_init(&bitstream, &buffer[byte], message_size * 8);
     rtcm3_decode_gal_eph_fnav_bitstream(&bitstream, &msg_eph);
 
     ck_assert(msg_eph.constellation == RTCM_CONSTELLATION_GAL);
@@ -1104,8 +1104,8 @@ static s32 rtcm_gal_inav_eph_cb(u8 *buffer, u16 length, void *context) {
     printf("GAL INAV Eph checked\n");
     checked_eph_gal_inav = true;
     rtcm_msg_eph msg_eph;
-    swiftnav_bitstream_t bitstream;
-    swiftnav_bitstream_init(&bitstream, &buffer[byte], message_size * 8);
+    swiftnav_in_bitstream_t bitstream;
+    swiftnav_in_bitstream_init(&bitstream, &buffer[byte], message_size * 8);
     rtcm3_decode_gal_eph_inav_bitstream(&bitstream, &msg_eph);
 
     ck_assert(msg_eph.constellation == RTCM_CONSTELLATION_GAL);

--- a/c/rtcm3tosbp/test/check_rtcm3.c
+++ b/c/rtcm3tosbp/test/check_rtcm3.c
@@ -10,23 +10,23 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <check.h>
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "check_rtcm3.h"
 
+#include <check.h>
 #include <libsbp/sbp.h>
 #include <libsbp/v4/observation.h>
+#include <math.h>
 #include <rtcm3/decode.h>
 #include <rtcm3/encode.h>
 #include <rtcm3/eph_decode.h>
 #include <rtcm3/eph_encode.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <swiftnav/ephemeris.h>
 #include <swiftnav/gnss_time.h>
 #include <swiftnav/sid_set.h>
 
-#include "check_rtcm3.h"
 #include "config.h"
 
 #define GPS_TOW_TOLERANCE 1e-4

--- a/c/rtcm3tosbp/test/check_rtcm3.h
+++ b/c/rtcm3tosbp/test/check_rtcm3.h
@@ -14,6 +14,7 @@
 #define CHECK_RTCM3_H
 
 #include <libsbp/legacy/logging.h>
+
 #include "../../gnss_converters/src/rtcm3_sbp_internal.h"
 #include "../../gnss_converters_extra/src/sbp_rtcm3_internal.h"
 

--- a/c/ubx2sbp/src/ubx2sbp.c
+++ b/c/ubx2sbp/src/ubx2sbp.c
@@ -11,11 +11,11 @@
  */
 
 #include <getopt.h>
+#include <gnss-converters/ubx_sbp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <gnss-converters/ubx_sbp.h>
 #include "ubx2sbp_main.h"
 
 static sbp_state_t sbp_state;

--- a/c/ubx2sbp/src/ubx2sbp_main.c
+++ b/c/ubx2sbp/src/ubx2sbp_main.c
@@ -10,13 +10,13 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+#include "ubx2sbp_main.h"
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
 #include <unistd.h>
-
-#include "ubx2sbp_main.h"
 
 static int readfn(uint8_t *buf, size_t len, void *context) {
   (void)context;

--- a/c/ubx2sbp/src/ubx2sbp_main.h
+++ b/c/ubx2sbp/src/ubx2sbp_main.h
@@ -1,6 +1,7 @@
 #ifndef UBX2SBP_MAIN_H
 #define UBX2SBP_MAIN_H
 
+#include <stddef.h>  // for size_t
 #include <stdint.h>
 
 typedef int (*readfn_ptr)(uint8_t *, size_t, void *);

--- a/c/ubx2sbp/test/check_ubx2sbp.c
+++ b/c/ubx2sbp/test/check_ubx2sbp.c
@@ -10,13 +10,8 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <gnss-converters/ubx_sbp.h>
-
-#include <ubx/decode.h>
-#include <ubx/encode.h>
-#include <ubx/ubx_messages.h>
-
 #include <check.h>
+#include <gnss-converters/ubx_sbp.h>
 #include <libsbp/edc.h>
 #include <libsbp/legacy/logging.h>
 #include <libsbp/v4/orientation.h>
@@ -24,14 +19,15 @@
 #include <libsbp/v4/system.h>
 #include <libsbp/v4/tracking.h>
 #include <libsbp/v4/vehicle.h>
-
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include <swiftnav/nav_meas.h>
 #include <swiftnav/signal.h>
+#include <ubx/decode.h>
+#include <ubx/encode.h>
+#include <ubx/ubx_messages.h>
 
 #include "config.h"
 


### PR DESCRIPTION
An open source publish of libswiftnav was done on 2023-09-30 (see https://github.com/swift-nav/libswiftnav/commit/f329a4052f36183fb5b094486a31a2ed7e970d8a) but the public version of gnss-converters was not updated correspondingly.  This PR updates libswiftnav to f329a4052f36183fb5b094486a31a2ed7e970d8a plus the minimum amount of changes required to compile due changes upstream.

An alternative to this PR would be to do a new open source publish to gnss-converters (which is probably a good idea anyway, given that it was last done on 2022-02-04).
